### PR TITLE
refactor(libc): update integer-to-string utilities and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+## BRANCH [refactor/hostdlib-int-to-string]
+
+### [2025-11-19] refactor(hostdlib): update integer-to-string utilities and cleanup
+
+BREAKING CHANGE:
+1. 现在 `Int64ToString[Ex]` 只保留基于 10 的转换，移除对其他进制的支持。
+2. 移除了 `FormatString` 函数，该函数将在未来版本中重新设计和实现。
+3. `32` 位整数转换函数已被移除。
+
+CHANGES:
+1. 添加 `*Ex` 系列函数以支持更灵活的 padding 选项。
+2. 修改了其它模块中对这些函数的调用以适应新的接口。
+

--- a/src/include/libc/hostdlib.h
+++ b/src/include/libc/hostdlib.h
@@ -12,13 +12,13 @@
 
 HO_PUBLIC_API void ReverseString(char *begin, char *end);
 
-HO_PUBLIC_API uint64_t Int32ToString(int32_t value, char *out, int base, BOOL prefix);
-
-HO_PUBLIC_API uint64_t Int64ToString(int64_t value, char *out, int base, BOOL prefix);
-
-HO_PUBLIC_API uint64_t UInt32ToString(uint32_t value, char *out, int base, BOOL prefix);
+HO_PUBLIC_API uint64_t Int64ToString(int64_t value, char *out, BOOL prefix);
 
 HO_PUBLIC_API uint64_t UInt64ToString(uint64_t value, char *out, int base, BOOL prefix);
+
+HO_PUBLIC_API uint64_t UInt64ToStringEx(uint64_t value, char *str, int base, int32_t padding, char padChar);
+
+HO_PUBLIC_API uint64_t Int64ToStringEx(int64_t val, char *buf, int32_t padding, char padChar);
 
 /**
  * FormatString: Formats a string into the provided buffer supporting various format specifiers (including some
@@ -29,4 +29,4 @@ HO_PUBLIC_API uint64_t UInt64ToString(uint64_t value, char *out, int base, BOOL 
  * @param ...: Additional arguments to format.
  * @returns: The length of the formatted string actually required (not including the null terminator).
  */
-HO_PUBLIC_API size_t FormatString(char *buffer, size_t len, const char *format, ...);
+// HO_PUBLIC_API size_t FormatString(char *buffer, size_t len, const char *format, ...);

--- a/src/kernel/console/console.c
+++ b/src/kernel/console/console.c
@@ -104,13 +104,13 @@ ConsoleWriteFmt(const char *fmt, ...)
         case 'd':
         case 'i': {
             int val = VA_ARG(args, int);
-            (void)Int32ToString(val, buf, 10, FALSE);
+            (void)Int64ToString(val, buf, FALSE);
             written += ConsoleWrite(buf);
             break;
         }
         case 'l': {
             int64_t val = VA_ARG(args, int64_t);
-            (void)Int64ToString(val, buf, 10, FALSE);
+            (void)Int64ToString(val, buf, FALSE);
             written += ConsoleWrite(buf);
             break;
         }
@@ -124,8 +124,8 @@ ConsoleWriteFmt(const char *fmt, ...)
             }
             else
             {
-                unsigned int val = VA_ARG(args, unsigned int);
-                (void)UInt32ToString(val, buf, 10, FALSE);
+                uint64_t val = VA_ARG(args, unsigned int);
+                (void)UInt64ToString(val, buf, 10, FALSE);
                 written += ConsoleWrite(buf);
             }
             break;

--- a/src/libc/stdlib/hostdlib.c
+++ b/src/libc/stdlib/hostdlib.c
@@ -5,7 +5,11 @@
 #define ITOA_32_BUFFER_SIZE 33
 #define ITOA_64_BUFFER_SIZE 65
 
-static inline size_t TryCopy(char *buffer, size_t len, size_t current, const char *src, size_t n);
+static void WriteIntDecimal(uint64_t num, char *buf, uint8_t digitSize);
+static void WriteIntTwoBase(uint64_t num, char *buf, uint8_t digitSize, int base);
+static uint8_t CountDecDigit(uint64_t n);
+static int FindMostSignificantBit(uint64_t num);
+static BOOL IsValidBase(int base);
 
 HO_PUBLIC_API void
 ReverseString(char *begin, char *end)
@@ -19,290 +23,180 @@ ReverseString(char *begin, char *end)
 }
 
 HO_PUBLIC_API uint64_t
-Int32ToString(int32_t value, char *str, int base, BOOL prefix)
+Int64ToString(int64_t value, char *str, BOOL prefix)
 {
-    if (str == NULL || base < 2 || base > 36)
-        return 0;
-
-    if (value < 0 && base == 10)
-    {
-        *str++ = '-';
-        return UInt32ToString((uint32_t)-value, str, base, prefix) + 1;
-    }
+    if (prefix)
+        return Int64ToStringEx(value, str, -1, '0');
     else
-    {
-        return UInt32ToString((uint32_t)value, str, base, prefix);
-    }
-}
-
-HO_PUBLIC_API uint64_t
-Int64ToString(int64_t value, char *str, int base, BOOL prefix)
-{
-    if (str == NULL || base < 2 || base > 36)
-        return 0;
-
-    if (value < 0 && base == 10)
-    {
-        *str++ = '-';
-        return UInt64ToString((uint64_t)-value, str, base, prefix) + 1;
-    }
-    else
-    {
-        return UInt64ToString((uint64_t)value, str, base, prefix);
-    }
-}
-
-static int
-_IsPowerOfTwo(int base)
-{
-    return (base & (base - 1)) == 0;
-}
-
-static int
-_BitsPerDigit(int base)
-{
-    switch (base)
-    {
-    case 2:
-        return 1;
-    case 4:
-        return 2;
-    case 8:
-        return 3;
-    case 16:
-        return 4;
-    case 32:
-        return 5;
-    default:
-        return 0;
-    }
-}
-
-HO_PUBLIC_API uint64_t
-UInt32ToString(uint32_t value, char *str, int base, BOOL prefix)
-{
-    char *currentPosition = str;
-    if (str == NULL || base < 2 || base > 36)
-    {
-        return 0;
-    }
-
-    if (value == 0)
-    {
-        *currentPosition++ = '0';
-        *currentPosition = '\0';
-        return 1;
-    }
-
-    while (value != 0)
-    {
-        uint32_t remainder = value % base;
-        *currentPosition++ = DIGITS_STR[remainder];
-        value = value / base;
-    }
-    *currentPosition = '\0';
-
-    uint64_t len = (uint64_t)(currentPosition - str);
-    ReverseString(str, currentPosition - 1);
-
-    if (prefix && _IsPowerOfTwo(base))
-    {
-        int bits = _BitsPerDigit(base);
-        if (bits > 0)
-        {
-            int totalBits = 32;
-            int digitsNeeded = (totalBits + bits - 1) / bits;
-
-            int currentLen = (int)len;
-            if (currentLen < digitsNeeded)
-            {
-                int pad = digitsNeeded - currentLen;
-                for (int i = currentLen; i >= 0; --i)
-                    str[i + pad] = str[i];
-                for (int i = 0; i < pad; ++i)
-                    str[i] = '0';
-
-                len = (uint64_t)digitsNeeded;
-            }
-        }
-    }
-
-    return len;
+        return Int64ToStringEx(value, str, 0, 0);
 }
 
 HO_PUBLIC_API uint64_t
 UInt64ToString(uint64_t value, char *str, int base, BOOL prefix)
 {
-    char *currentPosition = str;
-    if (str == NULL || base < 2 || base > 36)
-    {
-        return 0;
-    }
+    if (prefix)
+        return UInt64ToStringEx(value, str, base, -1, '0');
+    else
+        return UInt64ToStringEx(value, str, base, 0, 0);
+}
 
-    if (value == 0)
+HO_PUBLIC_API uint64_t
+UInt64ToStringEx(uint64_t value, char *str, int base, int32_t padding, char padChar)
+{
+    if (str == NULL || !IsValidBase(base))
+        return 0;
+
+    int totalDigits = 0;
+    if (base == 10)
     {
-        *currentPosition++ = '0';
+        totalDigits = CountDecDigit(value);
+        int toFill = 0;
+        if (padding > totalDigits)
+            toFill = padding - totalDigits;
+        WriteIntDecimal(value, str + toFill, totalDigits);
+        memset(str, padChar, toFill);
+        totalDigits += toFill;
     }
     else
     {
-        while (value != 0)
+        int toFill = 0;
+        int bitsPerDigit = FindMostSignificantBit(base);
+
+        if (value == 0)
+            totalDigits = 1;
+        else
         {
-            uint64_t remainder = value % base;
-            *currentPosition++ = DIGITS_STR[remainder];
-            value = value / base;
+            int bitsInValue = FindMostSignificantBit(value) + 1;
+            totalDigits = (bitsInValue + bitsPerDigit - 1) / bitsPerDigit;
         }
-    }
-    *currentPosition = '\0';
 
-    uint64_t len = (uint64_t)(currentPosition - str);
-    ReverseString(str, currentPosition - 1);
+        // special case for hex with negative padding means align to full digits
+        if (padding < 0)
+            padding = (64 + bitsPerDigit - 1) / bitsPerDigit;
+        if (padding > totalDigits)
+            toFill = padding - totalDigits;
 
-    if (prefix && _IsPowerOfTwo(base))
-    {
-        int bits = _BitsPerDigit(base);
-        if (bits > 0)
-        {
-            int totalBits = 64;
-            int digitsNeeded = (totalBits + bits - 1) / bits;
-
-            int currentLen = (int)len;
-            if (currentLen < digitsNeeded)
-            {
-                int pad = digitsNeeded - currentLen;
-                for (int i = currentLen; i >= 0; --i)
-                    str[i + pad] = str[i];
-                for (int i = 0; i < pad; ++i)
-                    str[i] = '0';
-                len = (uint64_t)digitsNeeded;
-            }
-        }
+        WriteIntTwoBase(value, str + toFill, totalDigits, base);
+        memset(str, padChar, toFill);
+        totalDigits += toFill;
     }
 
-    return len;
+    *(str + totalDigits) = '\0';
+    return totalDigits;
 }
 
-#define WRITE_CHAR(ch)                                                                                                 \
-    do                                                                                                                 \
-    {                                                                                                                  \
-        if (len > 0 && written < (len - 1))                                                                            \
-        {                                                                                                              \
-            buffer[written] = (char)(ch);                                                                              \
-            written++;                                                                                                 \
-        }                                                                                                              \
-        needed++;                                                                                                      \
-    } while (0)
-
-HO_PUBLIC_API size_t
-FormatString(char *buffer, size_t len, const char *format, ...)
+HO_PUBLIC_API uint64_t
+Int64ToStringEx(int64_t val, char *buf, int32_t padding, char padChar)
 {
-
-    VA_LIST args;
-    VA_START(args, format);
-    size_t written = 0, needed = 0;
-
-    const char *p = format;
-    while (*p)
+    uint64_t magnitude = 0;
+    uint8_t neg = 0;
+    if (val < 0)
     {
-        if (*p != '%')
-        {
-            WRITE_CHAR(*p);
-            ++p;
-            continue;
-        }
-        ++p; // Skip '%'
-        switch (*p)
-        {
-        case 'c': {
-            char c = (char)VA_ARG(args, int);
-            WRITE_CHAR((char)c);
-            break;
-        }
-        case 's': {
-            const char *s = VA_ARG(args, const char *);
-            if (s == NULL)
-                s = "(null)";
-            size_t n = strlen(s);
-            size_t copied = TryCopy(buffer, len, written, s, n);
-            written += copied;
-            needed += n;
-            break;
-        }
-        case 'd':
-        case 'i': {
-            int val = VA_ARG(args, int);
-            char temp[ITOA_32_BUFFER_SIZE];
-            size_t n = (size_t)Int32ToString(val, temp, 10, FALSE);
-            size_t copied = TryCopy(buffer, len, written, temp, n);
-            written += copied;
-            needed += n;
-            break;
-        }
-        case 'u': {
-            uint32_t val = VA_ARG(args, uint32_t);
-            char temp[ITOA_32_BUFFER_SIZE];
-            size_t n = (size_t)UInt32ToString(val, temp, 10, FALSE);
-            size_t copied = TryCopy(buffer, len, written, temp, n);
-            written += copied;
-            needed += n;
-            break;
-        }
-        // WARNING: HimuOS-specific: 'x' and 'X' behave the same way
-        // and always convert to uint64_t
-        case 'x':
-        case 'X': {
-            uint64_t val = VA_ARG(args, uint64_t);
-            char temp[ITOA_64_BUFFER_SIZE];
-            size_t n = (size_t)UInt64ToString(val, temp, 16, FALSE);
-            size_t copied = TryCopy(buffer, len, written, temp, n);
-            written += copied;
-            needed += n;
-            break;
-        }
-        case '%': {
-            WRITE_CHAR('%');
-            break;
-        }
-        case 'p': {
-            void *ptr = VA_ARG(args, void *);
-            uint64_t val = (uint64_t)ptr;
-            WRITE_CHAR('0');
-            WRITE_CHAR('X');
-            char temp[ITOA_64_BUFFER_SIZE];
-            size_t n = (size_t)UInt64ToString(val, temp, 16, TRUE);
-            written += TryCopy(buffer, len, written, temp, n);
-            needed += n;
-            break;
-        }
-        default:
-            WRITE_CHAR('%');
-            if (*p)
-                WRITE_CHAR(*p);
-            break;
-        }
-        ++p;
+        magnitude = (uint64_t)(-(val + 1)) + 1;
+        neg = 1;
+    }
+    else
+    {
+        magnitude = val;
     }
 
-    if (len > 0)
+    uint64_t digits = UInt64ToStringEx(magnitude, buf + neg, 10, padding - neg, padChar);
+    if (neg)
     {
-        size_t nullPos = (written < len) ? written : (len - 1);
-        buffer[nullPos] = '\0';
+        buf[0] = '-';
+        digits += 1;
     }
-
-    VA_END(args);
-    return needed;
+    return digits;
 }
 
-#undef WRITE_CHAR
+//
+// static functions
+//
 
-static inline size_t
-TryCopy(char *buffer, size_t len, size_t current, const char *src, size_t n)
+static void
+WriteIntDecimal(uint64_t num, char *buf, uint8_t digitSize)
 {
-    if (len > 0 && current < len - 1)
+    char *end = buf + digitSize;
+    if (num == 0)
     {
-        size_t available = len - 1 - current;
-        size_t toCopy = (n < available) ? n : available;
-        memcpy(&buffer[current], src, toCopy * sizeof(char));
-        return toCopy;
+        *(--end) = '0';
+        return;
     }
-    return 0;
+    while (num > 0)
+    {
+        *(--end) = DIGITS_STR[num % 10];
+        num /= 10;
+    }
+}
+
+static void
+WriteIntTwoBase(uint64_t num, char *buf, uint8_t digitSize, int base)
+{
+    int step = FindMostSignificantBit(base);
+    do
+    {
+        uint8_t digit = (uint8_t)(num & (base - 1));
+        buf[--digitSize] = DIGITS_STR[digit];
+        num >>= step;
+    } while (num != 0);
+}
+
+static uint8_t
+CountDecDigit(uint64_t n)
+{
+    if (n < 10)
+        return 1;
+    if (n < 100)
+        return 2;
+    if (n < 1000)
+        return 3;
+    if (n < 10000)
+        return 4;
+    if (n < 100000)
+        return 5;
+    if (n < 1000000)
+        return 6;
+    if (n < 10000000)
+        return 7;
+    if (n < 100000000)
+        return 8;
+    if (n < 1000000000)
+        return 9;
+    if (n < 10000000000)
+        return 10;
+    if (n < 100000000000)
+        return 11;
+    if (n < 1000000000000)
+        return 12;
+    if (n < 10000000000000)
+        return 13;
+    if (n < 100000000000000)
+        return 14;
+    if (n < 1000000000000000)
+        return 15;
+    if (n < 10000000000000000)
+        return 16;
+    if (n < 100000000000000000)
+        return 17;
+    if (n < 1000000000000000000)
+        return 18;
+    if (n < 10000000000000000000ull)
+        return 19;
+    return 20;
+}
+
+static int
+FindMostSignificantBit(uint64_t num)
+{
+    if (!num)
+        return -1;
+    return 63 - __builtin_clzll(num);
+}
+
+static BOOL
+IsValidBase(int base)
+{
+    if (base == 2 || base == 4 || base == 8 || base == 10 || base == 16 || base == 32)
+        return TRUE;
+    return FALSE;
 }


### PR DESCRIPTION
## BRANCH [refactor/hostdlib-int-to-string]

### [2025-11-19] refactor(hostdlib): update integer-to-string utilities and cleanup

BREAKING CHANGE:
1. 现在 `Int64ToString[Ex]` 只保留基于 10 的转换，移除对其他进制的支持。
2. 移除了 `FormatString` 函数，该函数将在未来版本中重新设计和实现。
3. `32` 位整数转换函数已被移除。

CHANGES:
1. 添加 `*Ex` 系列函数以支持更灵活的 padding 选项。
2. 修改了其它模块中对这些函数的调用以适应新的接口。