### PR TITLE
feat(console): implement format padding and stricter parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## BRANCH [refactor/hostdlib-int-to-string]
+## BRANCH [refactor/hostdlib-int-to-string] (merged)
 
 ### [2025-11-19] refactor(hostdlib): update integer-to-string utilities and cleanup
 
@@ -11,3 +11,21 @@ CHANGES:
 1. 添加 `*Ex` 系列函数以支持更灵活的 padding 选项。
 2. 修改了其它模块中对这些函数的调用以适应新的接口。
 
+## BRANCH [feature/console-kprintf-padding]
+
+### [2025-11-19] feat(console): implement format padding and stricter parsing
+
+BREAKING CHANGE:
+1. **严格的格式检查**：遇到未知的格式说明符（default case）时，内核现在会触发 `HO_KPANIC` (EC_ILLEGAL_ARGUMENT)，而不是原样输出字符。
+2. `%l` 说明符行为变更：必须显式跟随子类型（如 `%ld`, `%lu`, `%lx`），不再支持单独使用 `%l`。
+3. 移除对怪异格式的支持：如 `%ul` 等不再被支持。
+
+CHANGES:
+1. **实现格式化填充**：`ConsoleWriteFmt` 现在支持解析宽度和填充字符（支持空格和 `0` 填充）。
+   - 支持字符串 `%s` 的宽度对齐。
+   - 支持整数类型通过调用新版 `*Ex` 函数实现填充。
+2. **扩展 Long 类型支持**：完善了 `long` 类型的处理逻辑，显式支持 `%ld`, `%li`, `%lu`, `%lx/%lX`。
+3. **重构**：
+   - 优先处理 `%%` 转义，优化解析流程。
+   - 将整数打印逻辑迁移至 `hostdlib` 的 `Int64ToStringEx` 和 `UInt64ToStringEx` 接口。
+4. **更新调用代码**：修改了 `kprintf` 调用以适应新的格式化逻辑。

--- a/src/kernel/hodbg.c
+++ b/src/kernel/hodbg.c
@@ -95,12 +95,12 @@ ShowKernelPanicInfo(HO_STATUS code, HO_PANIC_CONTEXT *ctx)
     kprintf("** STOP INFORMATION **\n");
     if (ctx)
     {
-        kprintf("Message:\t%s\n", ctx->Message ? ctx->Message : "(null)");
-        kprintf("File:\t\t%s\n", ctx->FileName ? ctx->FileName : "(unknown)");
-        kprintf("Function:\t%s\n", ctx->FunctionName ? ctx->FunctionName : "(unknown)");
-        kprintf("Line:\t\t%ul\n", ctx->LineNumber);
-        kprintf("RIP:\t\t%p\n", ctx->InstructionPointer);
-        kprintf("RBP:\t\t%p\n", ctx->BasePointer);
+        kprintf("Message:     %s\n", ctx->Message ? ctx->Message : "(null)");
+        kprintf("File:        %s\n", ctx->FileName ? ctx->FileName : "(unknown)");
+        kprintf("Function:    %s\n", ctx->FunctionName ? ctx->FunctionName : "(unknown)");
+        kprintf("Line:        %lu\n", ctx->LineNumber);
+        kprintf("RIP:         %p\n", ctx->InstructionPointer);
+        kprintf("RBP:         %p\n", ctx->BasePointer);
         PrintStacktrace((uint64_t)ctx->BasePointer);
     }
     else


### PR DESCRIPTION
## BRANCH [feature/console-kprintf-padding]

### [2025-11-19] feat(console): implement format padding and stricter parsing

BREAKING CHANGE:
1. **严格的格式检查**：遇到未知的格式说明符（default case）时，内核现在会触发 `HO_KPANIC` (EC_ILLEGAL_ARGUMENT)，而不是原样输出字符。
2. `%l` 说明符行为变更：必须显式跟随子类型（如 `%ld`, `%lu`, `%lx`），不再支持单独使用 `%l`。
3. 移除对怪异格式的支持：如 `%ul` 等不再被支持。

CHANGES:
1. **实现格式化填充**：`ConsoleWriteFmt` 现在支持解析宽度和填充字符（支持空格和 `0` 填充）。
   - 支持字符串 `%s` 的宽度对齐。
   - 支持整数类型通过调用新版 `*Ex` 函数实现填充。
2. **扩展 Long 类型支持**：完善了 `long` 类型的处理逻辑，显式支持 `%ld`, `%li`, `%lu`, `%lx/%lX`。
3. **重构**：
   - 优先处理 `%%` 转义，优化解析流程。
   - 将整数打印逻辑迁移至 `hostdlib` 的 `Int64ToStringEx` 和 `UInt64ToStringEx` 接口。
4. **更新调用代码**：修改了 `kprintf` 调用以适应新的格式化逻辑。