### PR TITLE
Introduce ACPI support by adding ACPI structures and mapping functions

### DIFF
--- a/src/boot/v2/io.c
+++ b/src/boot/v2/io.c
@@ -225,6 +225,7 @@ PrintCapsule(const BOOT_CAPSULE *capsule, const CHAR16 *tag)
                        capsule->KrnlEntryPhys,
                        capsule->KrnlStackPhys,
                        capsule->KrnlIST1StackPhys);
+    ConsoleFormatWrite(L"| ACPI: rsdp=%p (HHDM)\r\n", capsule->AcpiRsdpPhys);
     ConsoleFormatWrite(L"| Paging: pml4=%p size=%u bytes\r\n",
                        capsule->PageTableInfo.Ptr,
                        capsule->PageTableInfo.Size);

--- a/src/include/arch/amd64/acpi.h
+++ b/src/include/arch/amd64/acpi.h
@@ -1,0 +1,40 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: acpi.h
+ * Description:
+ * Minimal ACPI structure definitions for AMD64.
+ *
+ * Only for AMD64 architecture.
+ * Copyright(c) 2024-2025 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include "_hobase.h"
+
+typedef struct __attribute__((packed)) ACPI_RSDP
+{
+    char Signature[8];
+    uint8_t Checksum;
+    char OemId[6];
+    uint8_t Revision;
+    uint32_t RsdtPhys;
+    uint32_t Length;
+    uint64_t XsdtPhys;
+    uint8_t ExtendedChecksum;
+    uint8_t Reserved[3];
+} ACPI_RSDP;
+
+typedef struct __attribute__((packed)) ACPI_SDT_HEADER
+{
+    char Signature[4];
+    uint32_t Length;
+    uint8_t Revision;
+    uint8_t Checksum;
+    char OemId[6];
+    char OemTableId[8];
+    uint32_t OemRevision;
+    uint32_t CreatorId;
+    uint32_t CreatorRevision;
+} ACPI_SDT_HEADER;

--- a/src/include/arch/amd64/efi_min.h
+++ b/src/include/arch/amd64/efi_min.h
@@ -100,6 +100,12 @@ struct EFI_GUID
     BYTE Data4[8];
 };
 
+typedef struct EFI_CONFIGURATION_TABLE
+{
+    struct EFI_GUID VendorGuid;
+    void *VendorTable;
+} EFI_CONFIGURATION_TABLE;
+
 struct EFI_SIMPLE_TEXT_INPUT_PROTOCOL
 {
     STRUCT_RESERVED(1, 8);
@@ -352,6 +358,8 @@ typedef struct EFI_SYSTEM_TABLE
     struct EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *ConsoleOutput;
     STRUCT_RESERVED(3, 24);
     struct EFI_BOOT_SERVICES *BootServices;
+    UINTN NumberOfTableEntries;
+    struct EFI_CONFIGURATION_TABLE *ConfigurationTable;
 } EFI_SYSTEM_TABLE;
 
 enum VIDEO_MODE_TYPE

--- a/src/include/boot/boot_capsule.h
+++ b/src/include/boot/boot_capsule.h
@@ -72,6 +72,7 @@ typedef struct BOOT_CAPSULE
     BOOT_CAPSULE_PAGE_LAYOUT PageLayout; // Actual page layout used
 
     HO_PHYSICAL_ADDRESS MemoryMapPhys;     // Physical address of the memory map, HHDM
+    HO_PHYSICAL_ADDRESS AcpiRsdpPhys;      // Physical address of ACPI RSDP, HHDM
     HO_PHYSICAL_ADDRESS KrnlEntryPhys;     // Physical address of the kernel loaded segments, BOOT_KRNL_ENTRY_VA
     HO_PHYSICAL_ADDRESS KrnlStackPhys;     // Physical address of the kernel stack, BOOT_KRNL_STACK_VA
     HO_PHYSICAL_ADDRESS KrnlIST1StackPhys; // Physical address of the IST#1 stack, BOOT_KRNL_IST1_STACK_VA

--- a/src/kernel/hoentry.c
+++ b/src/kernel/hoentry.c
@@ -27,7 +27,7 @@ kmain(BOOT_CAPSULE *capsule)
             gBasicCpuInfo.TimerFeatures & ARCH_TIMER_FEAT_INVARIANT ? "YES" : "NOT SUPPORTED");
     kprintf(" * Deadline mode:        %s\n\n",
             gBasicCpuInfo.TimerFeatures & ARCH_TIMER_FEAT_ONE_SHOT ? "YES" : "NOT SUPPORTED");
-
+    
     kprintf("Himu Operating System VERSION %s\n", KRNL_VERSTR);
     kprintf("Copyright(c) 2024-2025 Himu, ONLY FOR EDUCATIONAL PURPOSES.\n\n");
 


### PR DESCRIPTION
This pull request introduces ACPI table detection and mapping during the boot process, enabling the kernel to access ACPI information via the HHDM (Higher Half Direct Mapping). The changes add ACPI structure definitions, update bootloader logic to locate and map the ACPI RSDP and tables, and ensure the kernel validates ACPI presence and revision at startup.

**ACPI Table Detection and Mapping**

* Added minimal ACPI structure definitions (`ACPI_RSDP`, `ACPI_SDT_HEADER`) for AMD64 in `acpi.h`, enabling parsing and mapping of ACPI tables.
* Implemented logic in the bootloader (`FindAcpiRsdpPhys`, `IsGuidEqual`) to locate the ACPI RSDP physical address from UEFI configuration tables, supporting both ACPI 2.0 and 1.0 GUIDs.
* Extended the boot capsule (`BOOT_CAPSULE`) to store the ACPI RSDP physical address, and updated the memory mapping routine to map the RSDP and all referenced ACPI tables into the HHDM for kernel access. [[1]](diffhunk://#diff-d03247182617e498209bd263082699ad218900b4d6f61d6ad7bfad9651deef71R75) [[2]](diffhunk://#diff-16be585aa1aa38b05e79d9f9502ea2632ea8c5f1a947cd5ed1d4c446dcd83777L167-R181) [[3]](diffhunk://#diff-16be585aa1aa38b05e79d9f9502ea2632ea8c5f1a947cd5ed1d4c446dcd83777R407-R485)

**Bootloader and Kernel Integration**

* Updated bootloader initialization to detect and log the ACPI RSDP address, and print it in capsule diagnostics output. [[1]](diffhunk://#diff-67e0f3e60c014e21ec2888cad47003f97d4e52ae3fd636d6c3710b19d27d2bccR107-R117) [[2]](diffhunk://#diff-bbbcca6972c8ba2e2b18f002a6bc3d848fcbbcb50c51ec0ef6572786e45590b6R228)
* Kernel initialization now asserts the validity and revision of the ACPI RSDP, panicking if ACPI is missing or unsupported. [[1]](diffhunk://#diff-717afecc80a16cf210de533a013b606f858eb2bd7a43e522d8ec8c7a4bfcac90L35-R37) [[2]](diffhunk://#diff-717afecc80a16cf210de533a013b606f858eb2bd7a43e522d8ec8c7a4bfcac90R60-R76)

**UEFI Structures Update**

* Added missing UEFI configuration table and system table fields (`EFI_CONFIGURATION_TABLE`, `NumberOfTableEntries`, `ConfigurationTable`) to support ACPI table lookup. [[1]](diffhunk://#diff-7e0de77633f958204d200561b3e244ae4aca5872d96c077d9a2b4cf0b3c6fa1cR103-R108) [[2]](diffhunk://#diff-7e0de77633f958204d200561b3e244ae4aca5872d96c077d9a2b4cf0b3c6fa1cR361-R362)

**Code Organization**

* Included new ACPI header in relevant boot and kernel files for access to structure definitions. [[1]](diffhunk://#diff-16be585aa1aa38b05e79d9f9502ea2632ea8c5f1a947cd5ed1d4c446dcd83777R4) [[2]](diffhunk://#diff-717afecc80a16cf210de533a013b606f858eb2bd7a43e522d8ec8c7a4bfcac90R5)
* Added function prototypes for new ACPI-related routines in bootloader and kernel source files. [[1]](diffhunk://#diff-16be585aa1aa38b05e79d9f9502ea2632ea8c5f1a947cd5ed1d4c446dcd83777R13-R14) [[2]](diffhunk://#diff-717afecc80a16cf210de533a013b606f858eb2bd7a43e522d8ec8c7a4bfcac90R18)

These changes collectively enable the kernel to reliably discover and access ACPI tables, which is crucial for hardware enumeration and advanced power management.