### PR TITLE
Feature/uptime timestamp log v1

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,12 +29,17 @@ KRNL_BUILD_DATE := $(shell date +'%y%m%d')
 KRNL_VERSTR     := "$(KRNL_VER_MAJOR).$(KRNL_VER_MINOR).$(KRNL_VER_PATCH) $(KRNL_BUILD_DATE)"
 KRNL_ENTRY_POINT := 0xFFFF800000000000
 
+HO_DEBUG_BUILD ?= 1
+HO_ENABLE_TIMESTAMP_LOG ?= $(HO_DEBUG_BUILD)
+
 CFLAGS := -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Werror \
           -fno-stack-protector -nostdlib -fno-builtin -nostartfiles \
           -nodefaultlibs -nostdinc -ffreestanding -fdiagnostics-color \
           -c -m64 -g -mcmodel=large \
           -Isrc -Isrc/include -Isrc/include/libc \
-          -DKRNL_VERSTR=\"$(KRNL_VERSTR)\" -D__HO_DEBUG_BUILD__=1
+          -DKRNL_VERSTR=\"$(KRNL_VERSTR)\" \
+          -D__HO_DEBUG_BUILD__=$(HO_DEBUG_BUILD) \
+          -DHO_ENABLE_TIMESTAMP_LOG=$(HO_ENABLE_TIMESTAMP_LOG)
 
 LDFLAGS := -T himuos.ld -nostdlib -static -e kmain -Map=build/kernel/bin/kernel.map
 
@@ -113,6 +118,7 @@ SRCS_KERNEL_C := \
     src/kernel/ke/time/time_source.c                    \
     src/kernel/ke/time/sinks/tsc_sink.c                 \
     src/kernel/ke/time/sinks/hpet_sink.c                \
+    src/kernel/ke/log/log.c                             \
     src/arch/arch.c                                     \
     src/arch/amd64/idt.c                                \
     src/arch/amd64/cpu.c                                \

--- a/makefile
+++ b/makefile
@@ -31,6 +31,13 @@ KRNL_ENTRY_POINT := 0xFFFF800000000000
 
 HO_DEBUG_BUILD ?= 1
 HO_ENABLE_TIMESTAMP_LOG ?= $(HO_DEBUG_BUILD)
+SUDO ?= sudo
+
+ifeq ($(strip $(SUDO_PASSWORD)),)
+SUDO_RUN := $(SUDO)
+else
+SUDO_RUN := printf '%s\n' "$(SUDO_PASSWORD)" | $(SUDO) -S
+endif
 
 CFLAGS := -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Werror \
           -fno-stack-protector -nostdlib -fno-builtin -nostartfiles \
@@ -197,7 +204,7 @@ $(ESP_KERNEL_BIN): $(TARGET_KERNEL)
 
 run: $(ESP_BOOT_EFI) $(ESP_KERNEL_BIN)
 	@echo "Starting VM with EFI..."
-	@sudo qemu-system-x86_64 \
+	@$(SUDO_RUN) qemu-system-x86_64 \
 		-m 512M \
 		-bios /usr/share/OVMF/OVMF_CODE.fd \
 		-net none \

--- a/src/include/kernel/hodbg.h
+++ b/src/include/kernel/hodbg.h
@@ -10,9 +10,14 @@
 
 #include <hostdlib.h>
 #include <kernel/ke/console.h>
+#include <kernel/log.h>
 // #include "arch/amd64/idt.h"
 
+#if HO_ENABLE_TIMESTAMP_LOG
+#define kprintf(fmt, ...) KLogWriteFmt(fmt, ##__VA_ARGS__)
+#else
 #define kprintf(fmt, ...) ConsoleWriteFmt(fmt, ##__VA_ARGS__)
+#endif
 
 /**
  * @brief Structure representing the context information when a kernel panic occurs.

--- a/src/include/kernel/ke/console.h
+++ b/src/include/kernel/ke/console.h
@@ -11,6 +11,7 @@
 #include "_hobase.h"
 #include <drivers/video_driver.h>
 #include <lib/tui/bitmap_font.h>
+#include <stdarg.h>
 
 // ANSI Colors
 
@@ -70,5 +71,6 @@ HO_PUBLIC_API int ConsoleWriteChar(char c);
 HO_PUBLIC_API uint64_t ConsoleWrite(const char *str);
 
 HO_PUBLIC_API uint64_t ConsoleWriteFmt(const char *fmt, ...);
+HO_PUBLIC_API uint64_t ConsoleWriteVFmt(const char *fmt, VA_LIST args);
 
 HO_PUBLIC_API void ConsoleClearScreen(COLOR32 color);

--- a/src/include/kernel/ke/time_source.h
+++ b/src/include/kernel/ke/time_source.h
@@ -48,6 +48,12 @@ KeTimeSourceInit(HO_PHYSICAL_ADDRESS acpiRsdpPhys);
 HO_KERNEL_API uint64_t KeGetSystemUpRealTime(void);
 
 /**
+ * @brief Query whether time source is initialized and usable.
+ * @return TRUE if the active time source is ready.
+ */
+HO_KERNEL_API BOOL KeIsTimeSourceReady(void);
+
+/**
  * @brief Get the type of the active time source.
  * @return Kind enum.
  */

--- a/src/include/kernel/log.h
+++ b/src/include/kernel/log.h
@@ -1,0 +1,13 @@
+/**
+ * HimuOperatingSystem PUBLIC HEADER
+ *
+ * File: log.h
+ * Description: Kernel log APIs with optional uptime timestamp prefix.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include "_hobase.h"
+
+HO_KERNEL_API uint64_t KLogWriteFmt(const char *fmt, ...);

--- a/src/kernel/ke/console/console.c
+++ b/src/kernel/ke/console/console.c
@@ -22,56 +22,9 @@ static MUX_CONSOLE_SINK gMuxConsoleSink;
 #endif
 static BOOL gConsoleInitialized = FALSE;
 
-HO_PUBLIC_API HO_STATUS
-ConsoleInit(KE_VIDEO_DRIVER *driver, BITMAP_FONT_INFO *font)
+static uint64_t
+ConsoleWriteVFmtInternal(const char *fmt, VA_LIST args)
 {
-    if (gConsoleInitialized)
-        return EC_SUCCESS;
-#ifndef __HO_DEBUG_BUILD__
-    // In release builds, we only use GfxConSink
-    GfxConSinkInit(&gGfxConsoleSink, driver, font, 1);
-    ConDevInit(&gConsoleDevice, (CONSOLE_SINK *)&gGfxConsoleSink);
-#else
-    KeMuxConSinkInit(&gMuxConsoleSink);
-    KeGfxConSinkInit(&gGfxConsoleSink, driver, font, 1);
-    KeMuxConSinkAddSink(&gMuxConsoleSink, (KE_CONSOLE_SINK *)&gGfxConsoleSink); // As primary sink
-    KeSerialConSinkInit(&gSerialConsoleSink, COM1_PORT);
-    KeMuxConSinkAddSink(&gMuxConsoleSink, (KE_CONSOLE_SINK *)&gSerialConsoleSink);
-    KeConDevInit(&gConsoleDevice, (KE_CONSOLE_SINK *)&gMuxConsoleSink);
-#endif
-    gConsoleInitialized = TRUE;
-    return EC_SUCCESS;
-}
-
-HO_PUBLIC_API KE_CONSOLE_DEVICE *
-ConsoleGetGlobalDevice(void)
-{
-    return &gConsoleDevice;
-}
-
-HO_PUBLIC_API int
-ConsoleWriteChar(char c)
-{
-    if (!gConsoleInitialized)
-        return -1;
-
-    return KeConDevPutChar(&gConsoleDevice, c);
-}
-
-HO_PUBLIC_API uint64_t
-ConsoleWrite(const char *str)
-{
-    if (!gConsoleInitialized)
-        return 0;
-
-    return KeConDevPutStr(&gConsoleDevice, str);
-}
-
-HO_PUBLIC_API uint64_t
-ConsoleWriteFmt(const char *fmt, ...)
-{
-    VA_LIST args;
-    VA_START(args, fmt);
     char buf[MAX_FORMAT_BUFFER];
     uint64_t written = 0;
 
@@ -143,7 +96,7 @@ ConsoleWriteFmt(const char *fmt, ...)
         case 'd':
         case 'i': {
             int64_t val = VA_ARG(args, int);
-            (void) Int64ToStringEx(val, buf, width, pc);
+            (void)Int64ToStringEx(val, buf, width, pc);
             written += ConsoleWrite(buf);
             break;
         }
@@ -223,8 +176,70 @@ ConsoleWriteFmt(const char *fmt, ...)
             break;
         }
     }
-    VA_END(args);
+
     return written;
+}
+
+HO_PUBLIC_API HO_STATUS
+ConsoleInit(KE_VIDEO_DRIVER *driver, BITMAP_FONT_INFO *font)
+{
+    if (gConsoleInitialized)
+        return EC_SUCCESS;
+#ifndef __HO_DEBUG_BUILD__
+    // In release builds, we only use GfxConSink
+    GfxConSinkInit(&gGfxConsoleSink, driver, font, 1);
+    ConDevInit(&gConsoleDevice, (CONSOLE_SINK *)&gGfxConsoleSink);
+#else
+    KeMuxConSinkInit(&gMuxConsoleSink);
+    KeGfxConSinkInit(&gGfxConsoleSink, driver, font, 1);
+    KeMuxConSinkAddSink(&gMuxConsoleSink, (KE_CONSOLE_SINK *)&gGfxConsoleSink); // As primary sink
+    KeSerialConSinkInit(&gSerialConsoleSink, COM1_PORT);
+    KeMuxConSinkAddSink(&gMuxConsoleSink, (KE_CONSOLE_SINK *)&gSerialConsoleSink);
+    KeConDevInit(&gConsoleDevice, (KE_CONSOLE_SINK *)&gMuxConsoleSink);
+#endif
+    gConsoleInitialized = TRUE;
+    return EC_SUCCESS;
+}
+
+HO_PUBLIC_API KE_CONSOLE_DEVICE *
+ConsoleGetGlobalDevice(void)
+{
+    return &gConsoleDevice;
+}
+
+HO_PUBLIC_API int
+ConsoleWriteChar(char c)
+{
+    if (!gConsoleInitialized)
+        return -1;
+
+    return KeConDevPutChar(&gConsoleDevice, c);
+}
+
+HO_PUBLIC_API uint64_t
+ConsoleWrite(const char *str)
+{
+    if (!gConsoleInitialized)
+        return 0;
+
+    return KeConDevPutStr(&gConsoleDevice, str);
+}
+
+HO_PUBLIC_API uint64_t
+ConsoleWriteFmt(const char *fmt, ...)
+{
+    VA_LIST args;
+    VA_START(args, fmt);
+    uint64_t written = ConsoleWriteVFmtInternal(fmt, args);
+    VA_END(args);
+
+    return written;
+}
+
+HO_PUBLIC_API uint64_t
+ConsoleWriteVFmt(const char *fmt, VA_LIST args)
+{
+    return ConsoleWriteVFmtInternal(fmt, args);
 }
 
 HO_PUBLIC_API void ConsoleClearScreen(COLOR32 color)

--- a/src/kernel/ke/log/log.c
+++ b/src/kernel/ke/log/log.c
@@ -1,0 +1,38 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/log/log.c
+ * Description: Ke layer log mechanism with uptime timestamp prefix.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#include <kernel/log.h>
+
+#include <kernel/ke/console.h>
+#include <kernel/ke/time_source.h>
+#include <stdarg.h>
+
+HO_KERNEL_API uint64_t
+KLogWriteFmt(const char *fmt, ...)
+{
+    uint64_t written = 0;
+
+    if (KeIsTimeSourceReady())
+    {
+        uint64_t uptimeUs = KeGetSystemUpRealTime();
+        uint64_t sec = uptimeUs / 1000000ULL;
+        uint64_t fracUs = uptimeUs % 1000000ULL;
+        written += ConsoleWriteFmt("[%lu.%06lu] ", sec, fracUs);
+    }
+    else
+    {
+        written += ConsoleWrite("[----.------] ");
+    }
+
+    VA_LIST args;
+    VA_START(args, fmt);
+    written += ConsoleWriteVFmt(fmt, args);
+    VA_END(args);
+
+    return written;
+}

--- a/src/kernel/ke/time/time_source.c
+++ b/src/kernel/ke/time/time_source.c
@@ -124,6 +124,12 @@ KeGetSystemUpRealTime(void)
     return Mul64Div64(elapsed, 1000000ULL, gTimeDevice.FreqHz);
 }
 
+HO_KERNEL_API BOOL
+KeIsTimeSourceReady(void)
+{
+    return gTimeDevice.Initialized;
+}
+
 HO_KERNEL_API TIME_SOURCE_KIND
 KeGetTimeSourceKind(void)
 {


### PR DESCRIPTION
This pull request introduces a kernel logging mechanism with optional timestamp prefixes, improves flexibility in build configuration, and refactors console output handling. The most important changes are grouped below:

### Kernel Logging Enhancements

* Added a new logging API `KLogWriteFmt` in `src/kernel/ke/log/log.c` and its header `src/include/kernel/log.h`, which prefixes log messages with the system uptime if the time source is available. [[1]](diffhunk://#diff-fd1a5db07841036adf29f51bc43e5346b4835cdedafca760af07d43c44224f42R1-R38) [[2]](diffhunk://#diff-e7d3b329e524d5d584dc159cc10ba151884307e157965530fc59ad2352aa00dbR1-R13)
* Introduced `KeIsTimeSourceReady` in `src/kernel/ke/time/time_source.c` and its declaration in `src/include/kernel/ke/time_source.h` to allow checking if the time source is initialized before logging timestamps. [[1]](diffhunk://#diff-2e1504a7f83f513d42775ab430715f9a9141927ebf753f4030702db0373cdc61R127-R132) [[2]](diffhunk://#diff-44572c1d3b6e4346cf26725cfdacc3d1360e53f652da624f31f867d129932280R50-R55)

### Console Output Refactoring

* Refactored console output functions in `src/kernel/ke/console/console.c` to add `ConsoleWriteVFmt` for variadic argument support and reorganized function implementations for clarity. [[1]](diffhunk://#diff-72fa28805f917ccc2961fc670dae8216af15802da7b6203a83853eb5b85e6e82R74) [[2]](diffhunk://#diff-123f085ea5636d5372431a52f6bbf606af1037ef29f6bd8048a9e08acf7696b8L25-L74) [[3]](diffhunk://#diff-123f085ea5636d5372431a52f6bbf606af1037ef29f6bd8048a9e08acf7696b8R179-R244)
* Modified `kprintf` macro in `src/include/kernel/hodbg.h` to use timestamped logging when enabled via build configuration.

### Build System Improvements

* Made debug build and timestamp logging configurable via new `HO_DEBUG_BUILD` and `HO_ENABLE_TIMESTAMP_LOG` variables in the `makefile`, and improved sudo handling for VM startup. [[1]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R32-R49) [[2]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0L194-R207)
* Added the new log source file `src/kernel/ke/log/log.c` to the kernel build sources.

These changes collectively provide more informative kernel logs, improve build flexibility, and streamline console output handling.