### PR TITLE
feat(mm): implement full HHDM support from EFI memory map

### DIFF
--- a/src/boot/v2/blmm.c
+++ b/src/boot/v2/blmm.c
@@ -7,16 +7,20 @@
 #include "io.h"
 
 #define MIN_MEMMAP_PAGES          3  // 12KB for memory map at least
-#define MAX_PAGE_TABLE_POOL_PAGES 64 // 512KB for page table
+#define MAX_PAGE_TABLE_POOL_PAGES 256 // 1MB for page table
 #define IA32_APIC_BASE_MSR        0x1BU
 #define IA32_APIC_BASE_ADDR_MASK  0x00000000FFFFF000ULL
 
 static EFI_MEMORY_MAP *InitMemoryMap(void *base, size_t size);
 static EFI_STATUS FillMemoryMap(EFI_MEMORY_MAP *map);
+static EFI_STATUS
+MapFullHhdmFromMemoryMap(HOB_BALLOC *allocator, UINT64 pml4BasePhys, EFI_MEMORY_MAP *memoryMap, UINT64 nxFlag,
+                         UINT64 *mappedDescCount, UINT64 *highestPhysExclusive);
 static EFI_STATUS MapAcpiTables(HOB_BALLOC *allocator, UINT64 pml4BasePhys, HO_PHYSICAL_ADDRESS rsdpPhys);
 static EFI_STATUS MapAcpiRange(HOB_BALLOC *allocator, UINT64 pml4BasePhys, UINT64 tablePhys, UINT32 length);
 static BOOL IsSameMapping(UINT64 existingEntry, UINT64 targetPhys, UINT64 flags, UINT64 isPresent);
 static UINT64 GetNxFlag(void);
+static UINT64 GetHhdmMapFlags(EFI_MEMORY_TYPE type, UINT64 nxFlag);
 
 EFI_MEMORY_MAP *
 GetLoaderRuntimeMemoryMap()
@@ -122,15 +126,23 @@ CreateCapsule(const BOOT_CAPSULE_LAYOUT *layout)
 }
 
 UINT64
-CreateInitialMapping(BOOT_CAPSULE *capsule)
+CreateInitialMapping(BOOT_CAPSULE *capsule, EFI_MEMORY_MAP *memoryMap)
 {
     EFI_PHYSICAL_ADDRESS poolBase = 0;
     HOB_BALLOC pageTableAlloc;
     EFI_STATUS status;
     UINT64 nxFlag = GetNxFlag();
+    UINT64 mappedDescCount = 0;
+    UINT64 highestPhysExclusive = 0;
 
     do
     {
+        if (!capsule || !memoryMap)
+        {
+            LOG_ERROR("CreateInitialMapping: invalid arguments\r\n");
+            break;
+        }
+
         status =
             g_ST->BootServices->AllocatePages(AllocateAnyPages, EfiLoaderData, MAX_PAGE_TABLE_POOL_PAGES, &poolBase);
         if (EFI_ERROR(status))
@@ -159,6 +171,17 @@ CreateInitialMapping(BOOT_CAPSULE *capsule)
             LOG_ERROR("Failed to map lower 2GB memory: %k (0x%x)\r\n", status, status);
             break;
         }
+
+        // B. FULL HHDM from current EFI memory map
+        status = MapFullHhdmFromMemoryMap(&pageTableAlloc, pml4Phys, memoryMap, nxFlag, &mappedDescCount,
+                                          &highestPhysExclusive);
+        if (EFI_ERROR(status))
+        {
+            LOG_ERROR("Failed to map FULL HHDM: %k (0x%x)\r\n", status, status);
+            break;
+        }
+        LOG_INFO("FULL HHDM mapped %u descriptors, highest PA=%p\r\n",
+                 mappedDescCount, (void *)(UINTN)(highestPhysExclusive ? (highestPhysExclusive - 1ULL) : 0ULL));
 
         // B. BOOT_CAPSULE @ HHDM
         if (capsule->PageLayout.TotalPages > 0)
@@ -304,7 +327,15 @@ MapPage(MAP_PAGE_PARAMS *params)
         return EFI_SUCCESS;
     }
 
-    if (!(pdpt[pdptIndex] & PTE_PRESENT))
+    if (pdpt[pdptIndex] & PTE_PRESENT)
+    {
+        if (pdpt[pdptIndex] & PTE_PAGE_SIZE)
+        {
+            LOG_ERROR(L"Virtual address already mapped by 1GB entry: 0x%x\r\n", alignedAddrVirt);
+            return EFI_INVALID_PARAMETER;
+        }
+    }
+    else
     {
         UINT64 pdPhys = (UINT64)HobAlloc(allocator, PAGE_4KB, PAGE_4KB);
         if (pdPhys == 0)
@@ -335,7 +366,15 @@ MapPage(MAP_PAGE_PARAMS *params)
         return EFI_SUCCESS;
     }
 
-    if (!(pd[pdIndex] & PTE_PRESENT))
+    if (pd[pdIndex] & PTE_PRESENT)
+    {
+        if (pd[pdIndex] & PTE_PAGE_SIZE)
+        {
+            LOG_ERROR(L"Virtual address already mapped by 2MB entry: 0x%x\r\n", alignedAddrVirt);
+            return EFI_INVALID_PARAMETER;
+        }
+    }
+    else
     {
         UINT64 ptPhys = (UINT64)HobAlloc(allocator, PAGE_4KB, PAGE_4KB);
         if (ptPhys == 0)
@@ -436,8 +475,59 @@ FillMemoryMap(EFI_MEMORY_MAP *map)
     if (expectedMapSize > map->DescriptorTotalSize)
         return EFI_BUFFER_TOO_SMALL;
 
-    return g_ST->BootServices->GetMemoryMap(&map->DescriptorTotalSize, map->Segs, &map->MemoryMapKey,
-                                            &map->DescriptorSize, &map->DescriptorVersion);
+    status = g_ST->BootServices->GetMemoryMap(&map->DescriptorTotalSize, map->Segs, &map->MemoryMapKey,
+                                              &map->DescriptorSize, &map->DescriptorVersion);
+    if (EFI_ERROR(status))
+        return status;
+
+    map->DescriptorCount = (map->DescriptorSize == 0) ? 0 : (map->DescriptorTotalSize / map->DescriptorSize);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS
+MapFullHhdmFromMemoryMap(HOB_BALLOC *allocator, UINT64 pml4BasePhys, EFI_MEMORY_MAP *memoryMap, UINT64 nxFlag,
+                         UINT64 *mappedDescCount, UINT64 *highestPhysExclusive)
+{
+    if (!allocator || !memoryMap || !mappedDescCount || !highestPhysExclusive)
+        return EFI_INVALID_PARAMETER;
+
+    if (memoryMap->DescriptorSize < sizeof(EFI_MEMORY_DESCRIPTOR) || memoryMap->DescriptorSize == 0)
+        return EFI_INVALID_PARAMETER;
+
+    *mappedDescCount = 0;
+    *highestPhysExclusive = 0;
+
+    UINT64 descCount = memoryMap->DescriptorTotalSize / memoryMap->DescriptorSize;
+    for (UINT64 idx = 0; idx < descCount; ++idx)
+    {
+        UINT8 *descAddr = (UINT8 *)memoryMap->Segs + idx * memoryMap->DescriptorSize;
+        EFI_MEMORY_DESCRIPTOR *desc = (EFI_MEMORY_DESCRIPTOR *)descAddr;
+
+        if (!desc || desc->NumberOfPages == 0)
+            continue;
+
+        UINT64 mapSize = desc->NumberOfPages << PAGE_SHIFT;
+        UINT64 mapPhysStart = desc->PhysicalStart;
+        UINT64 mapPhysEndExclusive = mapPhysStart + mapSize;
+        if (mapPhysEndExclusive < mapPhysStart)
+            return EFI_INVALID_PARAMETER;
+
+        UINT64 flags = GetHhdmMapFlags((EFI_MEMORY_TYPE)desc->Type, nxFlag);
+        EFI_STATUS status =
+            MapRegion(allocator, pml4BasePhys, mapPhysStart, HHDM_BASE_VA + mapPhysStart, mapSize, flags);
+        if (EFI_ERROR(status))
+        {
+            LOG_ERROR("Map FULL HHDM failed at descriptor=%u type=%u phys=%p pages=%u: %k\r\n",
+                      idx, desc->Type, (void *)(UINTN)mapPhysStart, desc->NumberOfPages, status);
+            return status;
+        }
+
+        if (mapPhysEndExclusive > *highestPhysExclusive)
+            *highestPhysExclusive = mapPhysEndExclusive;
+        (*mappedDescCount)++;
+    }
+
+    return EFI_SUCCESS;
 }
 
 // WARNING: this function only maps first level table
@@ -541,6 +631,18 @@ static UINT64
 GetNxFlag(void)
 {
     return BootUseNx() ? PTE_NO_EXECUTE : 0;
+}
+
+static UINT64
+GetHhdmMapFlags(EFI_MEMORY_TYPE type, UINT64 nxFlag)
+{
+    if (type == EfiMemoryMappedIO || type == EfiMemoryMappedIOPortSpace)
+        return PTE_CACHE_DISABLE | PTE_WRITABLE | nxFlag;
+
+    if (type == EfiACPIReclaimMemory || type == EfiACPIMemoryNVS)
+        return nxFlag;
+
+    return PTE_WRITABLE | nxFlag;
 }
 
 static BOOL

--- a/src/boot/v2/blmm.h
+++ b/src/boot/v2/blmm.h
@@ -19,7 +19,7 @@ EFI_STATUS LoadMemoryMap(HO_PHYSICAL_ADDRESS mapBasePhys, UINT64 maxSize, OUT UI
 UINT64 GetCapsulePhysPages(const BOOT_CAPSULE_LAYOUT *block, BOOT_CAPSULE_PAGE_LAYOUT *pageLayout);
 BOOT_CAPSULE *CreateCapsule(const BOOT_CAPSULE_LAYOUT *layout);
 
-UINT64 CreateInitialMapping(BOOT_CAPSULE *capsule);
+UINT64 CreateInitialMapping(BOOT_CAPSULE *capsule, EFI_MEMORY_MAP *memoryMap);
 
 typedef struct
 {
@@ -34,4 +34,3 @@ typedef struct
 EFI_STATUS MapPage(MAP_PAGE_PARAMS *request);
 EFI_STATUS
 MapRegion(HOB_BALLOC *allocator, UINT64 pml4BasePhys, UINT64 physStart, UINT64 virtStart, UINT64 size, UINT64 flags);
-

--- a/src/boot/v2/bootloader.c
+++ b/src/boot/v2/bootloader.c
@@ -131,7 +131,7 @@ StagingKernel(const CHAR16 *path)
     if (!kBootUseNx)
         LOG_WARNING(L"CPU does not support NX bit; boot mappings will be executable\r\n");
 
-    size_t remain = CreateInitialMapping(capsule);
+    size_t remain = CreateInitialMapping(capsule, memoryMap);
     if (!remain)
     {
         LOG_ERROR(L"Failed to create initial page table mappings\r\n");
@@ -139,7 +139,12 @@ StagingKernel(const CHAR16 *path)
         goto handle_error;
     }
 
-    (void)InitCpuCoreLocalData(&capsule->CpuInfo, sizeof(capsule->CpuInfo));
+    if (!InitCpuCoreLocalData(&capsule->CpuInfo, sizeof(capsule->CpuInfo)))
+    {
+        LOG_ERROR(L"Failed to initialize CPU core local data\r\n");
+        status = EFI_OUT_OF_RESOURCES;
+        goto handle_error;
+    }
 
     if (!LoadKernel(image, imageSize, capsule))
     {
@@ -168,7 +173,6 @@ StagingKernel(const CHAR16 *path)
 
     if (kBootUseNx && !EnableNxe())
     {
-        LOG_ERROR(L"Failed to enable IA32_EFER.NXE\r\n");
         return EFI_DEVICE_ERROR;
     }
     __asm__ __volatile__("cli" ::: "memory");

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -3,6 +3,7 @@
 #include <kernel/hodbg.h>
 #include <arch/amd64/idt.h> // TODO: remove dependency on x86 arch
 #include <arch/amd64/acpi.h>
+#include <arch/amd64/efi_mem.h>
 #include <kernel/ke/time_source.h>
 #include <kernel/ke/clock_event.h>
 #include "assets/fonts/font8x16.h"
@@ -17,6 +18,12 @@ BITMAP_FONT_INFO gSystemFont;
 
 static void InitBitmapFont(void);
 static void InitCpuState(STAGING_BLOCK *block);
+static void VerifyHhdm(STAGING_BLOCK *block);
+static BOOL FindFirstSafeProbePage(UINT64 descStart, UINT64 descEndExclusive, UINT64 capsuleBase,
+                                   UINT64 capsuleEndExclusive, UINT64 pageTableBase, UINT64 pageTableEndExclusive,
+                                   UINT64 *probePhysOut);
+static void DumpHhdmProbeDiagnostics(const EFI_MEMORY_MAP *map, UINT64 capsuleBase, UINT64 capsuleEndExclusive,
+                                     UINT64 pageTableBase, UINT64 pageTableEndExclusive);
 static void AssertRsdp(HO_VIRTUAL_ADDRESS rsdpVirt);
 
 void
@@ -36,6 +43,7 @@ InitKernel(MAYBE_UNUSED STAGING_BLOCK *block)
         while (1)
             ;
     }
+    VerifyHhdm(block);
     AssertRsdp(HHDM_PHYS2VIRT(block->AcpiRsdpPhys));
     GetBasicCpuInfo(&gBasicCpuInfo);
 
@@ -70,6 +78,186 @@ InitCpuState(STAGING_BLOCK *block)
     data->Tss.RSP0 = HHDM_PHYS2VIRT(block->KrnlStackPhys) + block->Layout.KrnlStackSize;
     data->Tss.IST1 = HHDM_PHYS2VIRT(block->KrnlIST1StackPhys) + block->Layout.IST1StackSize;
     data->Tss.IOMapBase = sizeof(TSS64); // No IO permission bitmap
+}
+
+static void
+VerifyHhdm(STAGING_BLOCK *block)
+{
+    if (!block)
+    {
+        HO_KPANIC(EC_ILLEGAL_ARGUMENT, "Boot capsule missing");
+    }
+
+    EFI_MEMORY_MAP *map = (EFI_MEMORY_MAP *)HHDM_PHYS2VIRT(block->MemoryMapPhys);
+    if (!map || map->DescriptorSize < sizeof(EFI_MEMORY_DESCRIPTOR) || map->DescriptorSize == 0)
+    {
+        HO_KPANIC(EC_INVALID_STATE, "Boot memory map unavailable for HHDM verification");
+    }
+
+    UINT64 capsuleBase = block->BasePhys;
+    UINT64 capsuleEndExclusive = capsuleBase + (block->PageLayout.TotalPages << PAGE_SHIFT);
+    UINT64 pageTableBase = block->PageTableInfo.Ptr;
+    UINT64 pageTableEndExclusive = pageTableBase + block->PageTableInfo.Size;
+    UINT64 descCount = map->DescriptorTotalSize / map->DescriptorSize;
+    UINT64 probePhys = 0;
+    BOOL probeFound = FALSE;
+    BOOL zeroProbeFound = FALSE;
+
+    for (UINT64 idx = 0; idx < descCount; ++idx)
+    {
+        UINT8 *descAddr = (UINT8 *)map->Segs + idx * map->DescriptorSize;
+        EFI_MEMORY_DESCRIPTOR *desc = (EFI_MEMORY_DESCRIPTOR *)descAddr;
+
+        if (!desc || !IS_RECLAIMABLE_MEMORY(desc->Type) || desc->NumberOfPages == 0)
+            continue;
+
+        UINT64 descStart = desc->PhysicalStart;
+        UINT64 descEndExclusive = descStart + (desc->NumberOfPages << PAGE_SHIFT);
+        UINT64 candidateProbe = 0;
+        if (!FindFirstSafeProbePage(descStart, descEndExclusive, capsuleBase, capsuleEndExclusive, pageTableBase,
+                                    pageTableEndExclusive, &candidateProbe))
+            continue;
+
+        // Prefer a non-zero page when available; page 0 remains a fallback.
+        if (candidateProbe == 0)
+        {
+            zeroProbeFound = TRUE;
+            continue;
+        }
+
+        probePhys = candidateProbe;
+        probeFound = TRUE;
+        break;
+    }
+
+    if (!probeFound && zeroProbeFound)
+    {
+        probePhys = 0;
+        probeFound = TRUE;
+    }
+
+    if (!probeFound)
+    {
+        klog(KLOG_LEVEL_WARNING, "[MM] FULL HHDM smoke test skipped: no reclaimable probe page\n");
+        DumpHhdmProbeDiagnostics(map, capsuleBase, capsuleEndExclusive, pageTableBase, pageTableEndExclusive);
+        return;
+    }
+
+    volatile UINT64 *probeVirt = (volatile UINT64 *)HHDM_PHYS2VIRT(probePhys);
+    UINT64 oldValue = *probeVirt;
+    UINT64 pattern = 0x4848444D534D4F4BULL ^ probePhys;
+
+    *probeVirt = pattern;
+    UINT64 readBack = *probeVirt;
+    *probeVirt = oldValue;
+
+    if (readBack != pattern)
+    {
+        HO_KPANIC(EC_INVALID_STATE, "HHDM verification failed");
+    }
+
+    klog(KLOG_LEVEL_INFO, "[MM] FULL HHDM smoke test OK: PA=%p VA=%p\n",
+         (void *)(UINTN)probePhys, (void *)(UINTN)HHDM_PHYS2VIRT(probePhys));
+}
+
+static BOOL
+FindFirstSafeProbePage(UINT64 descStart, UINT64 descEndExclusive, UINT64 capsuleBase, UINT64 capsuleEndExclusive,
+                       UINT64 pageTableBase, UINT64 pageTableEndExclusive, UINT64 *probePhysOut)
+{
+    typedef struct HHDM_EXCLUDE_RANGE
+    {
+        UINT64 Start;
+        UINT64 EndExclusive;
+    } HHDM_EXCLUDE_RANGE;
+
+    HHDM_EXCLUDE_RANGE ranges[2] = {
+        {capsuleBase, capsuleEndExclusive},
+        {pageTableBase, pageTableEndExclusive},
+    };
+
+    if (ranges[1].Start < ranges[0].Start)
+    {
+        HHDM_EXCLUDE_RANGE tmp = ranges[0];
+        ranges[0] = ranges[1];
+        ranges[1] = tmp;
+    }
+
+    if (probePhysOut)
+        *probePhysOut = 0;
+
+    UINT64 candidate = descStart;
+    for (UINT64 idx = 0; idx < 2; ++idx)
+    {
+        UINT64 rangeStart = ranges[idx].Start;
+        UINT64 rangeEndExclusive = ranges[idx].EndExclusive;
+        if (rangeStart >= rangeEndExclusive || rangeEndExclusive <= descStart || rangeStart >= descEndExclusive)
+            continue;
+
+        if (candidate < rangeStart)
+        {
+            if (probePhysOut)
+                *probePhysOut = candidate;
+            return TRUE;
+        }
+
+        if (candidate < rangeEndExclusive)
+            candidate = rangeEndExclusive;
+
+        if (candidate >= descEndExclusive)
+            return FALSE;
+    }
+
+    if (candidate >= descEndExclusive)
+        return FALSE;
+
+    if (probePhysOut)
+        *probePhysOut = candidate;
+    return TRUE;
+}
+
+static void
+DumpHhdmProbeDiagnostics(const EFI_MEMORY_MAP *map, UINT64 capsuleBase, UINT64 capsuleEndExclusive,
+                         UINT64 pageTableBase, UINT64 pageTableEndExclusive)
+{
+    if (!map || map->DescriptorSize < sizeof(EFI_MEMORY_DESCRIPTOR) || map->DescriptorSize == 0)
+        return;
+
+    UINT64 descCount = map->DescriptorTotalSize / map->DescriptorSize;
+    klog(KLOG_LEVEL_INFO,
+         "[MM] probe filter ranges: capsule=[%p,%p) page_tables=[%p,%p) recorded_pt_bytes=%u desc_count=%u\n",
+         (void *)(UINTN)capsuleBase,
+         (void *)(UINTN)capsuleEndExclusive,
+         (void *)(UINTN)pageTableBase,
+         (void *)(UINTN)pageTableEndExclusive,
+         pageTableEndExclusive - pageTableBase,
+         descCount);
+
+    for (UINT64 idx = 0; idx < descCount; ++idx)
+    {
+        UINT8 *descAddr = (UINT8 *)map->Segs + idx * map->DescriptorSize;
+        EFI_MEMORY_DESCRIPTOR *desc = (EFI_MEMORY_DESCRIPTOR *)descAddr;
+        if (!desc || !IS_RECLAIMABLE_MEMORY(desc->Type) || desc->NumberOfPages == 0)
+            continue;
+
+        UINT64 descStart = desc->PhysicalStart;
+        UINT64 descEndExclusive = descStart + (desc->NumberOfPages << PAGE_SHIFT);
+        BOOL overlapsCapsule = !(descEndExclusive <= capsuleBase || descStart >= capsuleEndExclusive);
+        BOOL overlapsPageTables = !(descEndExclusive <= pageTableBase || descStart >= pageTableEndExclusive);
+        UINT64 firstSafeProbe = 0;
+        BOOL hasSafeProbe = FindFirstSafeProbePage(descStart, descEndExclusive, capsuleBase, capsuleEndExclusive,
+                                                   pageTableBase, pageTableEndExclusive, &firstSafeProbe);
+
+        klog(KLOG_LEVEL_INFO,
+             "[MM] reclaimable desc[%u]: type=%u phys=[%p,%p) pages=%u overlap(capsule=%u,pt=%u) first_safe=%p\n",
+             idx,
+             desc->Type,
+             (void *)(UINTN)descStart,
+             (void *)(UINTN)descEndExclusive,
+             desc->NumberOfPages,
+             overlapsCapsule,
+             overlapsPageTables,
+             (void *)(UINTN)(hasSafeProbe ? firstSafeProbe : 0));
+    }
 }
 
 static void


### PR DESCRIPTION
## Summary

Implement complete Higher Half Direct Map (HHDM) support by mapping all physical memory regions from the EFI memory map into the kernel's higher-half address space.

## Changes

### Bootloader (blmm.c)
- Increase page table pool from 64 to 256 pages (1MB) to accommodate full physical memory mapping
- Add `MapFullHhdmFromMemoryMap()` to iterate EFI memory descriptors and establish complete HHDM
- Add `GetHhdmMapFlags()` for memory-type-aware page flags:
  - MMIO regions: cache-disable + writable + NX
  - ACPI regions: NX only (read-only)
  - Other regions: writable + NX
- Improve `MapPage()` to detect and reject conflicts with existing 1GB/2MB large page mappings

### Kernel (init.c)
- Add `VerifyHhdm()` smoke test that probes a reclaimable page through the HHDM window
- Add diagnostic dump when no safe probe page is found

### Bug Fixes
- Add proper error handling for `InitCpuCoreLocalData()` in bootloader