### PR TITLE
feat(ke): implement KMUTEX with ownership tracking and safety guards

### DIFF
--- a/makefile
+++ b/makefile
@@ -22,6 +22,8 @@ CC          := gcc
 LD          := ld
 ASFLAGS     := -f elf64 -g -F dwarf
 
+BUILD_FLAVOR ?=
+
 KRNL_VER_MAJOR  := 1
 KRNL_VER_MINOR  := 0
 KRNL_VER_PATCH  := 0
@@ -62,13 +64,40 @@ CFLAGS := -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Werror \
           -D__HO_DEBUG_BUILD__=$(HO_DEBUG_BUILD) \
           -DHO_ENABLE_TIMESTAMP_LOG=$(HO_ENABLE_TIMESTAMP_LOG)
 
-LDFLAGS := -T himuos.ld -nostdlib -static -e kmain -Map=build/kernel/bin/kernel.map
+ifneq ($(strip $(HO_DEMO_TEST_DEFINE)),)
+CFLAGS += -DHO_DEMO_TEST_SELECTION=$(HO_DEMO_TEST_DEFINE) \
+          -DHO_DEMO_TEST_SELECTION_NAME=\"$(HO_DEMO_TEST_NAME)\"
+endif
+
+LDFLAGS = -T himuos.ld -nostdlib -static -e kmain -Map=$(KRN_BINDIR)/kernel.map
 
 # Output directories (explicit per-target)
 EFI_OBJDIR    := build/efi/obj
 EFI_BINDIR    := build/efi/bin
-KRN_OBJDIR    := build/kernel/obj
-KRN_BINDIR    := build/kernel/bin
+KRN_BUILDROOT := build/kernel$(if $(strip $(BUILD_FLAVOR)),/$(BUILD_FLAVOR),)
+KRN_OBJDIR    := $(KRN_BUILDROOT)/obj
+KRN_BINDIR    := $(KRN_BUILDROOT)/bin
+
+VALID_TEST_MODULES := thread event semaphore list
+TEST_MODULE_GOALS  := $(filter-out test,$(MAKECMDGOALS))
+TEST_MODULE        := $(if $(strip $(TEST_MODULE_GOALS)),$(firstword $(TEST_MODULE_GOALS)),all)
+TEST_BUILD_FLAVOR  := test-$(TEST_MODULE)
+
+TEST_DEFINE_all       := HO_DEMO_TEST_ALL
+TEST_DEFINE_thread    := HO_DEMO_TEST_THREAD
+TEST_DEFINE_event     := HO_DEMO_TEST_EVENT
+TEST_DEFINE_semaphore := HO_DEMO_TEST_SEMAPHORE
+
+ifneq ($(filter test,$(MAKECMDGOALS)),)
+ifneq ($(words $(TEST_MODULE_GOALS)),0)
+ifneq ($(words $(TEST_MODULE_GOALS)),1)
+$(error Usage: make test <module>. Available modules: thread event semaphore. Use `make test` to run all demos or `make test list` to list modules)
+endif
+ifneq ($(filter $(TEST_MODULE),$(VALID_TEST_MODULES)), $(TEST_MODULE))
+$(error Unknown test module '$(TEST_MODULE)'. Available modules: thread event semaphore. Use `make test list` to inspect supported modules)
+endif
+endif
+endif
 
 # ==============================================================================
 # Source Files
@@ -180,7 +209,7 @@ OBJS_KERNEL     := $(OBJS_KERNEL_C) $(OBJS_KERNEL_ASM)
 
 TARGET_KERNEL := $(KRN_BINDIR)/kernel.bin
 
-.PHONY: all clean run efi install clean_code vmware_img kernel debug run_iso
+.PHONY: all clean run efi install clean_code vmware_img kernel debug run_iso test thread event semaphore list
 
 all: efi kernel
 
@@ -247,6 +276,23 @@ run: $(ESP_BOOT_EFI) $(ESP_KERNEL_BIN)
 		-enable-kvm \
 		-drive file=fat:rw:esp,index=0,format=vvfat \
 		-serial stdio
+
+test:
+ifeq ($(TEST_MODULE),list)
+	@echo "Available test modules:"
+	@echo "  thread     - scheduler yield/sleep demo threads"
+	@echo "  event      - KEVENT wait/set/reset scenarios"
+	@echo "  semaphore  - KSEMAPHORE acquire/release scenarios"
+	@echo "Usage:"
+	@echo "  make test <module>"
+	@echo "  make test            # run all demo modules"
+else
+	@echo "Starting test module: $(TEST_MODULE)"
+	@$(MAKE) run BUILD_FLAVOR=$(TEST_BUILD_FLAVOR) HO_DEMO_TEST_NAME=$(TEST_MODULE) HO_DEMO_TEST_DEFINE=$(TEST_DEFINE_$(TEST_MODULE))
+endif
+
+thread event semaphore list:
+	@:
 		
 debug: $(ESP_BOOT_EFI) $(ESP_KERNEL_BIN)
 	@if [ -z "$(OVMF_CODE)" ] || [ ! -r "$(OVMF_CODE)" ]; then \

--- a/makefile
+++ b/makefile
@@ -78,23 +78,20 @@ KRN_BUILDROOT := build/kernel$(if $(strip $(BUILD_FLAVOR)),/$(BUILD_FLAVOR),)
 KRN_OBJDIR    := $(KRN_BUILDROOT)/obj
 KRN_BINDIR    := $(KRN_BUILDROOT)/bin
 
-VALID_TEST_MODULES := thread event semaphore list
+VALID_TEST_MODULES := schedule list
 TEST_MODULE_GOALS  := $(filter-out test,$(MAKECMDGOALS))
-TEST_MODULE        := $(if $(strip $(TEST_MODULE_GOALS)),$(firstword $(TEST_MODULE_GOALS)),all)
+TEST_MODULE        := $(if $(strip $(TEST_MODULE_GOALS)),$(firstword $(TEST_MODULE_GOALS)),list)
 TEST_BUILD_FLAVOR  := test-$(TEST_MODULE)
 
-TEST_DEFINE_all       := HO_DEMO_TEST_ALL
-TEST_DEFINE_thread    := HO_DEMO_TEST_THREAD
-TEST_DEFINE_event     := HO_DEMO_TEST_EVENT
-TEST_DEFINE_semaphore := HO_DEMO_TEST_SEMAPHORE
+TEST_DEFINE_schedule := HO_DEMO_TEST_SCHEDULE
 
 ifneq ($(filter test,$(MAKECMDGOALS)),)
 ifneq ($(words $(TEST_MODULE_GOALS)),0)
 ifneq ($(words $(TEST_MODULE_GOALS)),1)
-$(error Usage: make test <module>. Available modules: thread event semaphore. Use `make test` to run all demos or `make test list` to list modules)
+$(error Usage: make test <module>. Available modules: schedule. Use `make test` or `make test list` to inspect supported modules)
 endif
 ifneq ($(filter $(TEST_MODULE),$(VALID_TEST_MODULES)), $(TEST_MODULE))
-$(error Unknown test module '$(TEST_MODULE)'. Available modules: thread event semaphore. Use `make test list` to inspect supported modules)
+$(error Unknown test module '$(TEST_MODULE)'. Available modules: schedule. Use `make test list` to inspect supported modules)
 endif
 endif
 endif
@@ -209,7 +206,7 @@ OBJS_KERNEL     := $(OBJS_KERNEL_C) $(OBJS_KERNEL_ASM)
 
 TARGET_KERNEL := $(KRN_BINDIR)/kernel.bin
 
-.PHONY: all clean run efi install clean_code vmware_img kernel debug run_iso test thread event semaphore list
+.PHONY: all clean copy run efi install clean_code vmware_img kernel debug run_iso test schedule list
 
 all: efi kernel
 
@@ -245,23 +242,18 @@ $(KRN_OBJDIR)/%.o: src/%.asm
 	@nasm $(ASFLAGS) -o $@ $<
 
 # ------------------------------------------------------------------------------
-# Runtime artifacts for QEMU (vvfat): only refresh when binaries change
+# Runtime artifacts for QEMU (vvfat): always sync the current build flavor
 # ------------------------------------------------------------------------------
 ESP_BOOT_EFI   := esp/EFI/BOOT/BOOTX64.efi
 ESP_KERNEL_BIN := esp/kernel.bin
 
-copy: $(ESP_BOOT_EFI) $(ESP_KERNEL_BIN)
-	@echo "Copied EFI and kernel to esp/ directory."
+copy: $(TARGET_EFI) $(TARGET_KERNEL)
+	@mkdir -p $(dir $(ESP_BOOT_EFI)) $(dir $(ESP_KERNEL_BIN))
+	@cp $(TARGET_EFI) $(ESP_BOOT_EFI)
+	@cp $(TARGET_KERNEL) $(ESP_KERNEL_BIN)
+	@echo "Copied current build flavor to esp/ directory."
 
-$(ESP_BOOT_EFI): $(TARGET_EFI)
-	@mkdir -p $(dir $@)
-	@cp $< $@
-
-$(ESP_KERNEL_BIN): $(TARGET_KERNEL)
-	@mkdir -p $(dir $@)
-	@cp $< $@
-
-run: $(ESP_BOOT_EFI) $(ESP_KERNEL_BIN)
+run: copy
 	@if [ -z "$(OVMF_CODE)" ] || [ ! -r "$(OVMF_CODE)" ]; then \
 		echo "ERROR: OVMF firmware not found/readable."; \
 		echo "Set it explicitly, e.g. make run OVMF_CODE=/usr/share/edk2/x64/OVMF.4m.fd"; \
@@ -280,21 +272,19 @@ run: $(ESP_BOOT_EFI) $(ESP_KERNEL_BIN)
 test:
 ifeq ($(TEST_MODULE),list)
 	@echo "Available test modules:"
-	@echo "  thread     - scheduler yield/sleep demo threads"
-	@echo "  event      - KEVENT wait/set/reset scenarios"
-	@echo "  semaphore  - KSEMAPHORE acquire/release scenarios"
+	@echo "  schedule - scheduler demo suite (previous make run / make test all behavior)"
 	@echo "Usage:"
-	@echo "  make test <module>"
-	@echo "  make test            # run all demo modules"
+	@echo "  make test schedule   # run the scheduler demo suite"
+	@echo "  make test            # list available test modules"
 else
 	@echo "Starting test module: $(TEST_MODULE)"
 	@$(MAKE) run BUILD_FLAVOR=$(TEST_BUILD_FLAVOR) HO_DEMO_TEST_NAME=$(TEST_MODULE) HO_DEMO_TEST_DEFINE=$(TEST_DEFINE_$(TEST_MODULE))
 endif
 
-thread event semaphore list:
+schedule list:
 	@:
 		
-debug: $(ESP_BOOT_EFI) $(ESP_KERNEL_BIN)
+debug: copy
 	@if [ -z "$(OVMF_CODE)" ] || [ ! -r "$(OVMF_CODE)" ]; then \
 		echo "ERROR: OVMF firmware not found/readable."; \
 		echo "Set it explicitly, e.g. make debug OVMF_CODE=/usr/share/edk2/x64/OVMF.4m.fd"; \

--- a/makefile
+++ b/makefile
@@ -131,6 +131,7 @@ SRCS_KERNEL_C := \
     src/kernel/hoentry.c                                \
     src/kernel/init.c                                   \
     src/kernel/hodbg.c                                  \
+    src/kernel/demo.c                                   \
     src/kernel/ke/critical_section.c                    \
     src/kernel/ke/console/console.c                     \
     src/kernel/ke/console/console_device.c              \

--- a/src/include/_hobase.h
+++ b/src/include/_hobase.h
@@ -81,6 +81,7 @@ enum _HIMUOS_ERROR_CODE
     EC_OUT_OF_RESOURCE,     // Out of resource
     EC_INVALID_STATE,       // Operation cannot be performed in the current state
     EC_UNSUPPORTED_MACHINE, // The machine architecture is not supported
+    EC_TIMEOUT,             // Wait timed out before being satisfied
 };
 
 typedef int HO_STATUS;

--- a/src/include/kernel/demo.h
+++ b/src/include/kernel/demo.h
@@ -1,0 +1,12 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: demo.h
+ * Description: Kernel demo routines.
+ *
+ * Copyright(c) 2024-2025 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+void RunKernelDemos(void);

--- a/src/include/kernel/hodbg.h
+++ b/src/include/kernel/hodbg.h
@@ -16,7 +16,7 @@
 #if HO_ENABLE_TIMESTAMP_LOG
 #define klog(level, fmt, ...) KLogWriteFmt(level, fmt, ##__VA_ARGS__)
 #else
-#define klog(fmt, ...)
+#define klog(level, fmt, ...)
 #endif
 
 #define kprintf(fmt, ...) ConsoleWriteFmt(fmt, ##__VA_ARGS__)

--- a/src/include/kernel/ke/dispatcher.h
+++ b/src/include/kernel/ke/dispatcher.h
@@ -21,6 +21,7 @@ typedef enum KDISPATCHER_OBJECT_TYPE
 {
     DISPATCHER_TYPE_EVENT = 0,
     DISPATCHER_TYPE_SEMAPHORE,
+    DISPATCHER_TYPE_MUTEX,
 } KDISPATCHER_OBJECT_TYPE;
 
 // ─────────────────────────────────────────────────────────────

--- a/src/include/kernel/ke/dispatcher.h
+++ b/src/include/kernel/ke/dispatcher.h
@@ -1,0 +1,56 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/dispatcher.h
+ * Description:
+ * Ke Layer - Dispatcher object infrastructure: common header, wait block,
+ * and type definitions for the unified wait model.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <_hobase.h>
+#include <lib/common/linked_list.h>
+
+// ─────────────────────────────────────────────────────────────
+// Dispatcher object type enumeration
+// ─────────────────────────────────────────────────────────────
+
+typedef enum KDISPATCHER_OBJECT_TYPE
+{
+    DISPATCHER_TYPE_EVENT = 0,
+} KDISPATCHER_OBJECT_TYPE;
+
+// ─────────────────────────────────────────────────────────────
+// Dispatcher object common header
+// ─────────────────────────────────────────────────────────────
+
+typedef struct KDISPATCHER_HEADER
+{
+    uint32_t Signature; // KDISPATCHER_SIGNATURE when initialized
+    KDISPATCHER_OBJECT_TYPE Type;
+    int32_t SignalState;
+    LINKED_LIST_TAG WaitListHead;
+} KDISPATCHER_HEADER;
+
+// ─────────────────────────────────────────────────────────────
+// Wait block — embedded in each KTHREAD for single-object wait
+// ─────────────────────────────────────────────────────────────
+
+typedef struct KWAIT_BLOCK
+{
+    struct KDISPATCHER_HEADER *Dispatcher; // Object being waited on (NULL for timeout-only)
+    LINKED_LIST_TAG WaitListLink;          // Link in dispatcher object's wait list
+    LINKED_LIST_TAG TimeoutLink;           // Link in global timeout queue
+    uint64_t DeadlineNs;                   // Absolute timeout deadline (0 = no timeout)
+    HO_STATUS CompletionStatus;            // EC_SUCCESS or EC_TIMEOUT
+    BOOL Completed;                        // Prevents double completion
+} KWAIT_BLOCK;
+
+// ─────────────────────────────────────────────────────────────
+// Wait constants
+// ─────────────────────────────────────────────────────────────
+
+#define KDISPATCHER_SIGNATURE 0x4B444953U // 'KDIS'
+#define KE_WAIT_INFINITE 0xFFFFFFFFFFFFFFFFULL

--- a/src/include/kernel/ke/dispatcher.h
+++ b/src/include/kernel/ke/dispatcher.h
@@ -20,6 +20,7 @@
 typedef enum KDISPATCHER_OBJECT_TYPE
 {
     DISPATCHER_TYPE_EVENT = 0,
+    DISPATCHER_TYPE_SEMAPHORE,
 } KDISPATCHER_OBJECT_TYPE;
 
 // ─────────────────────────────────────────────────────────────
@@ -53,4 +54,4 @@ typedef struct KWAIT_BLOCK
 // ─────────────────────────────────────────────────────────────
 
 #define KDISPATCHER_SIGNATURE 0x4B444953U // 'KDIS'
-#define KE_WAIT_INFINITE 0xFFFFFFFFFFFFFFFFULL
+#define KE_WAIT_INFINITE      0xFFFFFFFFFFFFFFFFULL

--- a/src/include/kernel/ke/event.h
+++ b/src/include/kernel/ke/event.h
@@ -1,0 +1,48 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/event.h
+ * Description:
+ * Ke Layer - Kernel event object (KEVENT) — first dispatcher object.
+ * Manual-reset semantics: stays signaled until explicitly reset.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <_hobase.h>
+#include <kernel/ke/dispatcher.h>
+
+// ─────────────────────────────────────────────────────────────
+// KEVENT structure
+// ─────────────────────────────────────────────────────────────
+
+typedef struct KEVENT
+{
+    KDISPATCHER_HEADER Header;
+} KEVENT;
+
+// ─────────────────────────────────────────────────────────────
+// KEVENT API
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * @brief Initialize a kernel event object.
+ * @param event       Pointer to KEVENT to initialize.
+ * @param initialState TRUE = signaled, FALSE = non-signaled.
+ */
+HO_KERNEL_API void KeInitializeEvent(KEVENT *event, BOOL initialState);
+
+/**
+ * @brief Set an event to the signaled state.
+ *        All threads currently waiting on this event are released.
+ *        The event remains signaled until KeResetEvent is called.
+ * @param event Pointer to the KEVENT.
+ */
+HO_KERNEL_API void KeSetEvent(KEVENT *event);
+
+/**
+ * @brief Reset an event to the non-signaled state.
+ * @param event Pointer to the KEVENT.
+ */
+HO_KERNEL_API void KeResetEvent(KEVENT *event);

--- a/src/include/kernel/ke/kthread.h
+++ b/src/include/kernel/ke/kthread.h
@@ -67,6 +67,7 @@ typedef struct KTHREAD
 
     uint8_t Priority; // Reserved for multi-priority extension
     uint64_t Quantum; // Time slice remaining (nanoseconds)
+    uint32_t OwnedMutexCount;
 
     KWAIT_BLOCK WaitBlock; // Embedded wait record for unified wait model
 

--- a/src/include/kernel/ke/kthread.h
+++ b/src/include/kernel/ke/kthread.h
@@ -12,6 +12,7 @@
 #include <_hobase.h>
 #include <lib/common/linked_list.h>
 #include <kernel/ke/pool.h>
+#include <kernel/ke/dispatcher.h>
 
 // ─────────────────────────────────────────────────────────────
 // Thread entry point
@@ -67,10 +68,9 @@ typedef struct KTHREAD
     uint8_t Priority; // Reserved for multi-priority extension
     uint64_t Quantum; // Time slice remaining (nanoseconds)
 
-    uint64_t WakeDeadline; // Absolute wake deadline (monotonic ns, 0 = none)
+    KWAIT_BLOCK WaitBlock; // Embedded wait record for unified wait model
 
     LINKED_LIST_TAG ReadyLink; // Ready queue / terminated list intrusive node
-    LINKED_LIST_TAG SleepLink; // Sleep queue intrusive node
 
     KTHREAD_ENTRY EntryPoint;
     void *EntryArg;

--- a/src/include/kernel/ke/mutex.h
+++ b/src/include/kernel/ke/mutex.h
@@ -1,0 +1,44 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/mutex.h
+ * Description:
+ * Ke Layer - Kernel mutex object (KMUTEX).
+ * Owner-aware dispatcher object backed by the unified wait model.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <_hobase.h>
+#include <kernel/ke/dispatcher.h>
+
+struct KTHREAD;
+
+// ─────────────────────────────────────────────────────────────
+// KMUTEX structure
+// ─────────────────────────────────────────────────────────────
+
+typedef struct KMUTEX
+{
+    KDISPATCHER_HEADER Header;
+    struct KTHREAD *OwnerThread;
+} KMUTEX;
+
+// ─────────────────────────────────────────────────────────────
+// KMUTEX API
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * @brief Initialize a kernel mutex object.
+ * @param mutex Pointer to KMUTEX to initialize.
+ */
+HO_KERNEL_API void KeInitializeMutex(KMUTEX *mutex);
+
+/**
+ * @brief Release a kernel mutex owned by the current thread.
+ * @param mutex Pointer to the KMUTEX.
+ * @return EC_SUCCESS on success; EC_ILLEGAL_ARGUMENT on invalid arguments;
+ *         EC_INVALID_STATE if the current thread does not own the mutex.
+ */
+HO_KERNEL_API HO_STATUS KeReleaseMutex(KMUTEX *mutex);

--- a/src/include/kernel/ke/pool.h
+++ b/src/include/kernel/ke/pool.h
@@ -5,21 +5,21 @@
  * Description:
  * Ke Layer - Fixed-size kernel object pool (slab-like bootstrap arena).
  * CHARACTERISTICS:
- * 1. Zero Per-Object Overhead: Instead of maintaining external metadata or 
- * object headers, this pool time-multiplexes the memory slots. When a slot 
- * is free, it is treated as a KE_POOL_FREE_NODE to store the 'Next' pointer. 
+ * 1. Zero Per-Object Overhead: Instead of maintaining external metadata or
+ * object headers, this pool time-multiplexes the memory slots. When a slot
+ * is free, it is treated as a KE_POOL_FREE_NODE to store the 'Next' pointer.
  * When allocated, the entire slot is handed over to the caller as raw data.
  *
- * 2. Minimum Slot Size: To ensure the 'Next' pointer always fits, the slot 
- * size is strictly enforced to be at least sizeof(void*), even if the 
+ * 2. Minimum Slot Size: To ensure the 'Next' pointer always fits, the slot
+ * size is strictly enforced to be at least sizeof(void*), even if the
  * requested object size is smaller.
  *
- * 3. O(1) Complexity: Both allocation and deallocation are constant-time 
+ * 3. O(1) Complexity: Both allocation and deallocation are constant-time
  * operations, involving only simple pointer swaps at the head of the list.
  *
- * 4. Safety Warning: Since the free-list pointers reside within the objects 
- * themselves, any Use-After-Free (UAF) or buffer overflow by the consumer 
- * will directly corrupt the pool's internal linkage, leading to system-wide 
+ * 4. Safety Warning: Since the free-list pointers reside within the objects
+ * themselves, any Use-After-Free (UAF) or buffer overflow by the consumer
+ * will directly corrupt the pool's internal linkage, leading to system-wide
  * instability.
  *
  * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.

--- a/src/include/kernel/ke/scheduler.h
+++ b/src/include/kernel/ke/scheduler.h
@@ -12,6 +12,7 @@
 #include <_hobase.h>
 #include <kernel/ke/kthread.h>
 #include <kernel/ke/event.h>
+#include <kernel/ke/semaphore.h>
 
 // ─────────────────────────────────────────────────────────────
 // Constants
@@ -68,7 +69,7 @@ HO_KERNEL_API HO_NORETURN void KeThreadExit(void);
 
 /**
  * @brief Wait for a single dispatcher object to become signaled.
- * @param object    Pointer to a dispatcher object (KEVENT, etc.).
+ * @param object    Pointer to a dispatcher object (KEVENT, KSEMAPHORE, etc.).
  * @param timeoutNs Timeout in nanoseconds. KE_WAIT_INFINITE = wait forever;
  *                  0 = zero-timeout poll (never blocks).
  * @return EC_SUCCESS if the object was signaled; EC_TIMEOUT if timed out.

--- a/src/include/kernel/ke/scheduler.h
+++ b/src/include/kernel/ke/scheduler.h
@@ -11,6 +11,7 @@
 
 #include <_hobase.h>
 #include <kernel/ke/kthread.h>
+#include <kernel/ke/event.h>
 
 // ─────────────────────────────────────────────────────────────
 // Constants
@@ -64,6 +65,15 @@ HO_KERNEL_API HO_STATUS KeThreadStart(KTHREAD *thread);
 HO_KERNEL_API void KeYield(void);
 HO_KERNEL_API void KeSleep(uint64_t durationNs);
 HO_KERNEL_API HO_NORETURN void KeThreadExit(void);
+
+/**
+ * @brief Wait for a single dispatcher object to become signaled.
+ * @param object    Pointer to a dispatcher object (KEVENT, etc.).
+ * @param timeoutNs Timeout in nanoseconds. KE_WAIT_INFINITE = wait forever;
+ *                  0 = zero-timeout poll (never blocks).
+ * @return EC_SUCCESS if the object was signaled; EC_TIMEOUT if timed out.
+ */
+HO_KERNEL_API HO_STATUS KeWaitForSingleObject(void *object, uint64_t timeoutNs);
 
 HO_KERNEL_API KTHREAD *KeGetCurrentThread(void);
 

--- a/src/include/kernel/ke/scheduler.h
+++ b/src/include/kernel/ke/scheduler.h
@@ -12,6 +12,7 @@
 #include <_hobase.h>
 #include <kernel/ke/kthread.h>
 #include <kernel/ke/event.h>
+#include <kernel/ke/mutex.h>
 #include <kernel/ke/semaphore.h>
 
 // ─────────────────────────────────────────────────────────────
@@ -69,7 +70,7 @@ HO_KERNEL_API HO_NORETURN void KeThreadExit(void);
 
 /**
  * @brief Wait for a single dispatcher object to become signaled.
- * @param object    Pointer to a dispatcher object (KEVENT, KSEMAPHORE, etc.).
+ * @param object    Pointer to a dispatcher object (KEVENT, KSEMAPHORE, KMUTEX, etc.).
  * @param timeoutNs Timeout in nanoseconds. KE_WAIT_INFINITE = wait forever;
  *                  0 = zero-timeout poll (never blocks).
  * @return EC_SUCCESS if the object was signaled; EC_TIMEOUT if timed out.

--- a/src/include/kernel/ke/semaphore.h
+++ b/src/include/kernel/ke/semaphore.h
@@ -1,0 +1,45 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/semaphore.h
+ * Description:
+ * Ke Layer - Kernel semaphore object (KSEMAPHORE).
+ * Counted dispatcher object backed by the unified wait model.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <_hobase.h>
+#include <kernel/ke/dispatcher.h>
+
+// ─────────────────────────────────────────────────────────────
+// KSEMAPHORE structure
+// ─────────────────────────────────────────────────────────────
+
+typedef struct KSEMAPHORE
+{
+    KDISPATCHER_HEADER Header;
+    int32_t Limit;
+} KSEMAPHORE;
+
+// ─────────────────────────────────────────────────────────────
+// KSEMAPHORE API
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * @brief Initialize a kernel semaphore object.
+ * @param semaphore    Pointer to KSEMAPHORE to initialize.
+ * @param initialCount Initial number of available permits.
+ * @param limit        Maximum number of permits the semaphore can hold.
+ * @return EC_SUCCESS on success; EC_ILLEGAL_ARGUMENT on invalid parameters.
+ */
+HO_KERNEL_API HO_STATUS KeInitializeSemaphore(KSEMAPHORE *semaphore, int32_t initialCount, int32_t limit);
+
+/**
+ * @brief Release one or more permits to a semaphore.
+ * @param semaphore    Pointer to the KSEMAPHORE.
+ * @param releaseCount Number of permits to release.
+ * @return EC_SUCCESS on success; EC_ILLEGAL_ARGUMENT on invalid parameters or overflow.
+ */
+HO_KERNEL_API HO_STATUS KeReleaseSemaphore(KSEMAPHORE *semaphore, int32_t releaseCount);

--- a/src/kernel/demo.c
+++ b/src/kernel/demo.c
@@ -1,0 +1,179 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: demo.c
+ * Description: Kernel demo routines for testing various components.
+ *
+ * Copyright(c) 2024-2025 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#include <kernel/demo.h>
+#include <kernel/hodbg.h>
+#include <kernel/ke/scheduler.h>
+#include <kernel/ke/kthread.h>
+#include <kernel/ke/event.h>
+
+static void TestThreadA(void *arg);
+static void TestThreadB(void *arg);
+static void EventProducerThread(void *arg);
+static void EventConsumerThread(void *arg);
+static void EventPollThread(void *arg);
+
+static KEVENT gTestEvent;
+
+void RunKernelDemos(void)
+{
+    // Create test kernel threads (KeSleep compatibility)
+    KTHREAD *threadA = NULL;
+    KTHREAD *threadB = NULL;
+
+    HO_STATUS status;
+    status = KeThreadCreate(&threadA, TestThreadA, (void *)0xAAAA);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create thread A");
+
+    status = KeThreadCreate(&threadB, TestThreadB, (void *)0xBBBB);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create thread B");
+
+    status = KeThreadStart(threadA);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start thread A");
+
+    status = KeThreadStart(threadB);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start thread B");
+
+    // ── KEVENT demo ──────────────────────────────────────────
+    KeInitializeEvent(&gTestEvent, FALSE);
+
+    KTHREAD *producer = NULL;
+    KTHREAD *consumer = NULL;
+    KTHREAD *poller = NULL;
+
+    status = KeThreadCreate(&producer, EventProducerThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create producer thread");
+
+    status = KeThreadCreate(&consumer, EventConsumerThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create consumer thread");
+
+    status = KeThreadCreate(&poller, EventPollThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create poller thread");
+
+    status = KeThreadStart(consumer);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start consumer thread");
+
+    status = KeThreadStart(poller);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start poller thread");
+
+    status = KeThreadStart(producer);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start producer thread");
+}
+
+// ─────────────────────────────────────────────────────────────
+// Test kernel threads
+// ─────────────────────────────────────────────────────────────
+
+static void
+TestThreadA(void *arg)
+{
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+    for (uint32_t i = 0; i < 5; i++)
+    {
+        klog(KLOG_LEVEL_INFO, "[THREAD-%u] tick %u (arg=%p)\n", id, i, arg);
+        KeSleep(50000000ULL); // 50 ms
+    }
+    klog(KLOG_LEVEL_INFO, "[THREAD-%u] done, exiting\n", id);
+}
+
+static void
+TestThreadB(void *arg)
+{
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+    for (uint32_t i = 0; i < 5; i++)
+    {
+        klog(KLOG_LEVEL_INFO, "[THREAD-%u] tick %u (arg=%p)\n", id, i, arg);
+        KeYield();
+        KeSleep(30000000ULL); // 30 ms
+    }
+    klog(KLOG_LEVEL_INFO, "[THREAD-%u] done, exiting\n", id);
+}
+
+// ─────────────────────────────────────────────────────────────
+// KEVENT demo threads
+// ─────────────────────────────────────────────────────────────
+
+static void
+EventProducerThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    // Wait 100ms then signal the event
+    klog(KLOG_LEVEL_INFO, "[PRODUCER-%u] sleeping 100ms before signaling event\n", id);
+    KeSleep(100000000ULL); // 100 ms
+
+    klog(KLOG_LEVEL_INFO, "[PRODUCER-%u] >>> KeSetEvent\n", id);
+    KeSetEvent(&gTestEvent);
+
+    // Wait a bit, then reset and re-signal
+    KeSleep(50000000ULL); // 50 ms
+    klog(KLOG_LEVEL_INFO, "[PRODUCER-%u] >>> KeResetEvent\n", id);
+    KeResetEvent(&gTestEvent);
+
+    KeSleep(50000000ULL); // 50 ms
+    klog(KLOG_LEVEL_INFO, "[PRODUCER-%u] >>> KeSetEvent (second)\n", id);
+    KeSetEvent(&gTestEvent);
+
+    klog(KLOG_LEVEL_INFO, "[PRODUCER-%u] done\n", id);
+}
+
+static void
+EventConsumerThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    // Infinite wait — should block until producer signals
+    klog(KLOG_LEVEL_INFO, "[CONSUMER-%u] waiting for event (infinite)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestEvent, KE_WAIT_INFINITE);
+    klog(KLOG_LEVEL_INFO, "[CONSUMER-%u] event wait returned: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+
+    // Immediate satisfy while the manual-reset event remains signaled
+    klog(KLOG_LEVEL_INFO, "[CONSUMER-%u] waiting for event again (expect immediate SUCCESS)\n", id);
+    result = KeWaitForSingleObject(&gTestEvent, 200000000ULL);
+    klog(KLOG_LEVEL_INFO, "[CONSUMER-%u] event wait returned: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+
+    // Wait again after reset so the second signal drives a blocking wakeup
+    KeSleep(80000000ULL); // 80ms — event should be reset by now
+    klog(KLOG_LEVEL_INFO, "[CONSUMER-%u] waiting for event after reset (200ms timeout)\n", id);
+    result = KeWaitForSingleObject(&gTestEvent, 200000000ULL);
+    klog(KLOG_LEVEL_INFO, "[CONSUMER-%u] event wait returned: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+
+    klog(KLOG_LEVEL_INFO, "[CONSUMER-%u] done\n", id);
+}
+
+static void
+EventPollThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    // Zero-timeout poll — should return TIMEOUT immediately since event not signaled
+    klog(KLOG_LEVEL_INFO, "[POLLER-%u] zero-timeout poll (expect TIMEOUT)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestEvent, 0);
+    klog(KLOG_LEVEL_INFO, "[POLLER-%u] poll result: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+
+    // Finite timeout wait — should timeout before producer signals
+    klog(KLOG_LEVEL_INFO, "[POLLER-%u] finite timeout wait 30ms (expect TIMEOUT)\n", id);
+    result = KeWaitForSingleObject(&gTestEvent, 30000000ULL);
+    klog(KLOG_LEVEL_INFO, "[POLLER-%u] finite wait result: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+
+    klog(KLOG_LEVEL_INFO, "[POLLER-%u] done\n", id);
+}

--- a/src/kernel/demo.c
+++ b/src/kernel/demo.c
@@ -12,16 +12,64 @@
 #include <kernel/ke/scheduler.h>
 #include <kernel/ke/kthread.h>
 #include <kernel/ke/event.h>
+#include <kernel/ke/semaphore.h>
+
+#define HO_DEMO_TEST_ALL       0
+#define HO_DEMO_TEST_THREAD    1
+#define HO_DEMO_TEST_EVENT     2
+#define HO_DEMO_TEST_SEMAPHORE 3
+
+#ifndef HO_DEMO_TEST_SELECTION
+#define HO_DEMO_TEST_SELECTION HO_DEMO_TEST_ALL
+#endif
+
+#ifndef HO_DEMO_TEST_SELECTION_NAME
+#define HO_DEMO_TEST_SELECTION_NAME "all"
+#endif
 
 static void TestThreadA(void *arg);
 static void TestThreadB(void *arg);
 static void EventProducerThread(void *arg);
 static void EventConsumerThread(void *arg);
 static void EventPollThread(void *arg);
+static void SemaphoreImmediateThread(void *arg);
+static void SemaphorePollThread(void *arg);
+static void SemaphoreWaiterOneThread(void *arg);
+static void SemaphoreWaiterTwoThread(void *arg);
+static void SemaphoreTimeoutThread(void *arg);
+static void SemaphoreDelayedWaiterThread(void *arg);
+static void SemaphoreReleaserThread(void *arg);
 
 static KEVENT gTestEvent;
+static KSEMAPHORE gTestSemaphore;
 
-void RunKernelDemos(void)
+static void RunThreadDemo(void);
+static void RunEventDemo(void);
+static void RunSemaphoreDemo(void);
+
+void
+RunKernelDemos(void)
+{
+    klog(KLOG_LEVEL_INFO, "[DEMO] Selected module: %s\n", HO_DEMO_TEST_SELECTION_NAME);
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_ALL || HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_THREAD)
+    {
+        RunThreadDemo();
+    }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_ALL || HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_EVENT)
+    {
+        RunEventDemo();
+    }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_ALL || HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_SEMAPHORE)
+    {
+        RunSemaphoreDemo();
+    }
+}
+
+static void
+RunThreadDemo(void)
 {
     // Create test kernel threads (KeSleep compatibility)
     KTHREAD *threadA = NULL;
@@ -43,8 +91,13 @@ void RunKernelDemos(void)
     status = KeThreadStart(threadB);
     if (status != EC_SUCCESS)
         HO_KPANIC(status, "Failed to start thread B");
+}
 
+static void
+RunEventDemo(void)
+{
     // ── KEVENT demo ──────────────────────────────────────────
+    HO_STATUS status;
     KeInitializeEvent(&gTestEvent, FALSE);
 
     KTHREAD *producer = NULL;
@@ -74,6 +127,80 @@ void RunKernelDemos(void)
     status = KeThreadStart(producer);
     if (status != EC_SUCCESS)
         HO_KPANIC(status, "Failed to start producer thread");
+}
+
+static void
+RunSemaphoreDemo(void)
+{
+    // ── KSEMAPHORE demo ──────────────────────────────────────
+    HO_STATUS status;
+    status = KeInitializeSemaphore(&gTestSemaphore, 1, 4);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to initialize test semaphore");
+
+    KTHREAD *semImmediate = NULL;
+    KTHREAD *semPoll = NULL;
+    KTHREAD *semWaiterOne = NULL;
+    KTHREAD *semWaiterTwo = NULL;
+    KTHREAD *semTimeout = NULL;
+    KTHREAD *semDelayedWaiter = NULL;
+    KTHREAD *semReleaser = NULL;
+
+    status = KeThreadCreate(&semImmediate, SemaphoreImmediateThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create semaphore immediate thread");
+
+    status = KeThreadCreate(&semPoll, SemaphorePollThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create semaphore poll thread");
+
+    status = KeThreadCreate(&semWaiterOne, SemaphoreWaiterOneThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create semaphore waiter one thread");
+
+    status = KeThreadCreate(&semWaiterTwo, SemaphoreWaiterTwoThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create semaphore waiter two thread");
+
+    status = KeThreadCreate(&semTimeout, SemaphoreTimeoutThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create semaphore timeout thread");
+
+    status = KeThreadCreate(&semDelayedWaiter, SemaphoreDelayedWaiterThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create semaphore delayed waiter thread");
+
+    status = KeThreadCreate(&semReleaser, SemaphoreReleaserThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create semaphore releaser thread");
+
+    status = KeThreadStart(semImmediate);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start semaphore immediate thread");
+
+    status = KeThreadStart(semPoll);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start semaphore poll thread");
+
+    status = KeThreadStart(semWaiterOne);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start semaphore waiter one thread");
+
+    status = KeThreadStart(semWaiterTwo);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start semaphore waiter two thread");
+
+    status = KeThreadStart(semTimeout);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start semaphore timeout thread");
+
+    status = KeThreadStart(semDelayedWaiter);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start semaphore delayed waiter thread");
+
+    status = KeThreadStart(semReleaser);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start semaphore releaser thread");
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -176,4 +303,98 @@ EventPollThread(void *arg)
     klog(KLOG_LEVEL_INFO, "[POLLER-%u] finite wait result: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
 
     klog(KLOG_LEVEL_INFO, "[POLLER-%u] done\n", id);
+}
+
+// ─────────────────────────────────────────────────────────────
+// KSEMAPHORE demo threads
+// ─────────────────────────────────────────────────────────────
+
+static void
+SemaphoreImmediateThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    klog(KLOG_LEVEL_INFO, "[SEMI-%u] immediate acquire (expect SUCCESS)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestSemaphore, KE_WAIT_INFINITE);
+    klog(KLOG_LEVEL_INFO, "[SEMI-%u] acquire result: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+}
+
+static void
+SemaphorePollThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    KeSleep(10000000ULL); // 10 ms — allow the initial permit to be consumed first
+
+    klog(KLOG_LEVEL_INFO, "[SEMPOLL-%u] zero-timeout poll (expect TIMEOUT)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestSemaphore, 0);
+    klog(KLOG_LEVEL_INFO, "[SEMPOLL-%u] poll result: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+}
+
+static void
+SemaphoreWaiterOneThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    KeSleep(10000000ULL); // 10 ms
+    klog(KLOG_LEVEL_INFO, "[SEMWAIT1-%u] blocking wait (expect release #1)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestSemaphore, KE_WAIT_INFINITE);
+    klog(KLOG_LEVEL_INFO, "[SEMWAIT1-%u] wait result: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+}
+
+static void
+SemaphoreWaiterTwoThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    KeSleep(10000000ULL); // 10 ms
+    klog(KLOG_LEVEL_INFO, "[SEMWAIT2-%u] blocking wait (expect release #2)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestSemaphore, KE_WAIT_INFINITE);
+    klog(KLOG_LEVEL_INFO, "[SEMWAIT2-%u] wait result: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+}
+
+static void
+SemaphoreTimeoutThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    KeSleep(10000000ULL); // 10 ms
+    klog(KLOG_LEVEL_INFO, "[SEMTIME-%u] finite wait 30ms (expect TIMEOUT)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestSemaphore, 30000000ULL);
+    klog(KLOG_LEVEL_INFO, "[SEMTIME-%u] wait result: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+}
+
+static void
+SemaphoreDelayedWaiterThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    KeSleep(350000000ULL); // 350 ms — join after release #1, before release #2
+
+    klog(KLOG_LEVEL_INFO, "[SEMWAIT3-%u] delayed blocking wait (expect release #2)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestSemaphore, KE_WAIT_INFINITE);
+    klog(KLOG_LEVEL_INFO, "[SEMWAIT3-%u] wait result: %s\n", id, result == EC_SUCCESS ? "SUCCESS" : "TIMEOUT");
+}
+
+static void
+SemaphoreReleaserThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    KeSleep(200000000ULL); // 200 ms
+    klog(KLOG_LEVEL_INFO, "[SEMREL-%u] >>> KeReleaseSemaphore(1)\n", id);
+    HO_STATUS status = KeReleaseSemaphore(&gTestSemaphore, 1);
+    klog(KLOG_LEVEL_INFO, "[SEMREL-%u] release #1 status: 0x%x\n", id, status);
+
+    KeSleep(200000000ULL); // 200 ms
+    klog(KLOG_LEVEL_INFO, "[SEMREL-%u] >>> KeReleaseSemaphore(3)\n", id);
+    status = KeReleaseSemaphore(&gTestSemaphore, 3);
+    klog(KLOG_LEVEL_INFO, "[SEMREL-%u] release #2 status: 0x%x\n", id, status);
 }

--- a/src/kernel/demo.c
+++ b/src/kernel/demo.c
@@ -11,20 +11,26 @@
 #include <kernel/hodbg.h>
 #include <kernel/ke/scheduler.h>
 #include <kernel/ke/kthread.h>
+#include <kernel/ke/critical_section.h>
 #include <kernel/ke/event.h>
+#include <kernel/ke/mutex.h>
 #include <kernel/ke/semaphore.h>
 
-#define HO_DEMO_TEST_ALL       0
-#define HO_DEMO_TEST_THREAD    1
-#define HO_DEMO_TEST_EVENT     2
-#define HO_DEMO_TEST_SEMAPHORE 3
+#define HO_DEMO_TEST_NONE       0
+#define HO_DEMO_TEST_SCHEDULE   1
+#define HO_DEMO_TEST_THREAD     2
+#define HO_DEMO_TEST_EVENT      3
+#define HO_DEMO_TEST_SEMAPHORE  4
+#define HO_DEMO_TEST_MUTEX      5
+#define HO_DEMO_TEST_GUARD_WAIT 6
+#define HO_DEMO_TEST_OWNED_EXIT 7
 
 #ifndef HO_DEMO_TEST_SELECTION
-#define HO_DEMO_TEST_SELECTION HO_DEMO_TEST_ALL
+#define HO_DEMO_TEST_SELECTION HO_DEMO_TEST_NONE
 #endif
 
 #ifndef HO_DEMO_TEST_SELECTION_NAME
-#define HO_DEMO_TEST_SELECTION_NAME "all"
+#define HO_DEMO_TEST_SELECTION_NAME "none"
 #endif
 
 static void TestThreadA(void *arg);
@@ -39,33 +45,82 @@ static void SemaphoreWaiterTwoThread(void *arg);
 static void SemaphoreTimeoutThread(void *arg);
 static void SemaphoreDelayedWaiterThread(void *arg);
 static void SemaphoreReleaserThread(void *arg);
+static void MutexOwnerThread(void *arg);
+static void MutexPollThread(void *arg);
+static void MutexWaiterOneThread(void *arg);
+static void MutexWaiterTwoThread(void *arg);
+static void MutexNonOwnerReleaseThread(void *arg);
+static void CriticalSectionWaitViolationThread(void *arg);
+static void OwnedMutexExitViolationThread(void *arg);
 
 static KEVENT gTestEvent;
 static KSEMAPHORE gTestSemaphore;
+static KMUTEX gTestMutex;
+static KEVENT gCriticalSectionGuardEvent;
+static KMUTEX gOwnedExitMutex;
 
+static void RunScheduleDemo(void);
 static void RunThreadDemo(void);
 static void RunEventDemo(void);
 static void RunSemaphoreDemo(void);
+static void RunMutexDemo(void);
+static void RunGuardWaitDemo(void);
+static void RunOwnedExitDemo(void);
 
 void
 RunKernelDemos(void)
 {
-    klog(KLOG_LEVEL_INFO, "[DEMO] Selected module: %s\n", HO_DEMO_TEST_SELECTION_NAME);
+    klog(KLOG_LEVEL_INFO, "[DEMO] Selected profile: %s\n", HO_DEMO_TEST_SELECTION_NAME);
 
-    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_ALL || HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_THREAD)
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_NONE)
+    {
+        return;
+    }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_SCHEDULE)
+    {
+        RunScheduleDemo();
+        return;
+    }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_THREAD)
     {
         RunThreadDemo();
     }
 
-    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_ALL || HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_EVENT)
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_EVENT)
     {
         RunEventDemo();
     }
 
-    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_ALL || HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_SEMAPHORE)
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_SEMAPHORE)
     {
         RunSemaphoreDemo();
     }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_MUTEX)
+    {
+        RunMutexDemo();
+    }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_GUARD_WAIT)
+    {
+        RunGuardWaitDemo();
+    }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_OWNED_EXIT)
+    {
+        RunOwnedExitDemo();
+    }
+}
+
+static void
+RunScheduleDemo(void)
+{
+    RunThreadDemo();
+    RunEventDemo();
+    RunSemaphoreDemo();
+    RunMutexDemo();
 }
 
 static void
@@ -201,6 +256,93 @@ RunSemaphoreDemo(void)
     status = KeThreadStart(semReleaser);
     if (status != EC_SUCCESS)
         HO_KPANIC(status, "Failed to start semaphore releaser thread");
+}
+
+static void
+RunMutexDemo(void)
+{
+    HO_STATUS status;
+    KTHREAD *mutexOwner = NULL;
+    KTHREAD *mutexPoll = NULL;
+    KTHREAD *mutexWaiterOne = NULL;
+    KTHREAD *mutexWaiterTwo = NULL;
+    KTHREAD *mutexNonOwner = NULL;
+
+    KeInitializeMutex(&gTestMutex);
+
+    status = KeThreadCreate(&mutexOwner, MutexOwnerThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create mutex owner thread");
+
+    status = KeThreadCreate(&mutexPoll, MutexPollThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create mutex poll thread");
+
+    status = KeThreadCreate(&mutexWaiterOne, MutexWaiterOneThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create mutex waiter one thread");
+
+    status = KeThreadCreate(&mutexWaiterTwo, MutexWaiterTwoThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create mutex waiter two thread");
+
+    status = KeThreadCreate(&mutexNonOwner, MutexNonOwnerReleaseThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create mutex non-owner thread");
+
+    status = KeThreadStart(mutexOwner);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start mutex owner thread");
+
+    status = KeThreadStart(mutexPoll);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start mutex poll thread");
+
+    status = KeThreadStart(mutexWaiterOne);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start mutex waiter one thread");
+
+    status = KeThreadStart(mutexWaiterTwo);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start mutex waiter two thread");
+
+    status = KeThreadStart(mutexNonOwner);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start mutex non-owner thread");
+}
+
+static void
+RunGuardWaitDemo(void)
+{
+    HO_STATUS status;
+    KTHREAD *violator = NULL;
+
+    KeInitializeEvent(&gCriticalSectionGuardEvent, TRUE);
+
+    status = KeThreadCreate(&violator, CriticalSectionWaitViolationThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create guard-wait violation thread");
+
+    status = KeThreadStart(violator);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start guard-wait violation thread");
+}
+
+static void
+RunOwnedExitDemo(void)
+{
+    HO_STATUS status;
+    KTHREAD *violator = NULL;
+
+    KeInitializeMutex(&gOwnedExitMutex);
+
+    status = KeThreadCreate(&violator, OwnedMutexExitViolationThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create owned-exit violation thread");
+
+    status = KeThreadStart(violator);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start owned-exit violation thread");
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -397,4 +539,120 @@ SemaphoreReleaserThread(void *arg)
     klog(KLOG_LEVEL_INFO, "[SEMREL-%u] >>> KeReleaseSemaphore(3)\n", id);
     status = KeReleaseSemaphore(&gTestSemaphore, 3);
     klog(KLOG_LEVEL_INFO, "[SEMREL-%u] release #2 status: 0x%x\n", id, status);
+}
+
+// ─────────────────────────────────────────────────────────────
+// KMUTEX demo threads
+// ─────────────────────────────────────────────────────────────
+
+static void
+MutexOwnerThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    klog(KLOG_LEVEL_INFO, "[MUTOWNER-%u] immediate acquire (expect SUCCESS)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestMutex, KE_WAIT_INFINITE);
+    klog(KLOG_LEVEL_INFO, "[MUTOWNER-%u] acquire result: 0x%x\n", id, result);
+
+    klog(KLOG_LEVEL_INFO, "[MUTOWNER-%u] self-acquire (expect EC_INVALID_STATE)\n", id);
+    result = KeWaitForSingleObject(&gTestMutex, KE_WAIT_INFINITE);
+    klog(KLOG_LEVEL_INFO, "[MUTOWNER-%u] self-acquire result: 0x%x\n", id, result);
+
+    KeSleep(150000000ULL); // 150 ms — allow poller/non-owner/waiters to line up
+
+    klog(KLOG_LEVEL_INFO, "[MUTOWNER-%u] >>> KeReleaseMutex\n", id);
+    result = KeReleaseMutex(&gTestMutex);
+    klog(KLOG_LEVEL_INFO, "[MUTOWNER-%u] release status: 0x%x\n", id, result);
+}
+
+static void
+MutexPollThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    KeSleep(10000000ULL); // 10 ms — owner should already hold the mutex
+
+    klog(KLOG_LEVEL_INFO, "[MUTPOLL-%u] zero-timeout poll (expect TIMEOUT)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestMutex, 0);
+    klog(KLOG_LEVEL_INFO, "[MUTPOLL-%u] poll result: 0x%x\n", id, result);
+}
+
+static void
+MutexWaiterOneThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    KeSleep(20000000ULL); // 20 ms
+    klog(KLOG_LEVEL_INFO, "[MUTWAIT1-%u] blocking wait (expect handoff #1)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestMutex, KE_WAIT_INFINITE);
+    klog(KLOG_LEVEL_INFO, "[MUTWAIT1-%u] wait result: 0x%x\n", id, result);
+
+    KeSleep(80000000ULL); // 80 ms — keep waiter #2 queued
+    klog(KLOG_LEVEL_INFO, "[MUTWAIT1-%u] >>> KeReleaseMutex (expect handoff #2)\n", id);
+    result = KeReleaseMutex(&gTestMutex);
+    klog(KLOG_LEVEL_INFO, "[MUTWAIT1-%u] release status: 0x%x\n", id, result);
+}
+
+static void
+MutexWaiterTwoThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    KeSleep(90000000ULL); // 90 ms — queue behind waiter #1 but ahead of owner release
+    klog(KLOG_LEVEL_INFO, "[MUTWAIT2-%u] blocking wait (expect handoff #2)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gTestMutex, KE_WAIT_INFINITE);
+    klog(KLOG_LEVEL_INFO, "[MUTWAIT2-%u] wait result: 0x%x\n", id, result);
+
+    klog(KLOG_LEVEL_INFO, "[MUTWAIT2-%u] >>> KeReleaseMutex (expect final SUCCESS)\n", id);
+    result = KeReleaseMutex(&gTestMutex);
+    klog(KLOG_LEVEL_INFO, "[MUTWAIT2-%u] release status: 0x%x\n", id, result);
+}
+
+static void
+MutexNonOwnerReleaseThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    KeSleep(40000000ULL); // 40 ms — owner should still hold the mutex
+
+    klog(KLOG_LEVEL_INFO, "[MUTFAIL-%u] non-owner release (expect EC_INVALID_STATE)\n", id);
+    HO_STATUS result = KeReleaseMutex(&gTestMutex);
+    klog(KLOG_LEVEL_INFO, "[MUTFAIL-%u] release result: 0x%x\n", id, result);
+}
+
+// ─────────────────────────────────────────────────────────────
+// Safety regression demo threads
+// ─────────────────────────────────────────────────────────────
+
+static void
+CriticalSectionWaitViolationThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+    KE_CRITICAL_SECTION criticalSection = {0};
+
+    klog(KLOG_LEVEL_INFO, "[GUARDWAIT-%u] entering critical section before wait (expect panic)\n", id);
+    KeEnterCriticalSection(&criticalSection);
+
+    (void)KeWaitForSingleObject(&gCriticalSectionGuardEvent, 0);
+    HO_KPANIC(EC_INVALID_STATE, "Critical-section wait guard did not fire");
+}
+
+static void
+OwnedMutexExitViolationThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+
+    klog(KLOG_LEVEL_INFO, "[OWNEDEXIT-%u] acquire mutex before exit (expect SUCCESS)\n", id);
+    HO_STATUS result = KeWaitForSingleObject(&gOwnedExitMutex, KE_WAIT_INFINITE);
+    klog(KLOG_LEVEL_INFO, "[OWNEDEXIT-%u] acquire result: 0x%x\n", id, result);
+
+    klog(KLOG_LEVEL_INFO, "[OWNEDEXIT-%u] calling KeThreadExit while owning mutex (expect panic)\n", id);
+    KeThreadExit();
 }

--- a/src/kernel/hodbg.c
+++ b/src/kernel/hodbg.c
@@ -21,7 +21,8 @@ KrGetStatusMessage(HO_STATUS status)
         "Operation not supported",
         "Out of resource",
         "Operation cannot be performed in the current state",
-        "The machine architecture is not supported"
+        "The machine architecture is not supported",
+        "Wait timed out before being satisfied"
     };
     // clang-format on
     uint64_t index = (uint64_t)status;

--- a/src/kernel/hoentry.c
+++ b/src/kernel/hoentry.c
@@ -14,10 +14,9 @@
 #include <kernel/ke/clock_event.h>
 #include <kernel/ke/sysinfo.h>
 #include <kernel/ke/scheduler.h>
+#include <kernel/demo.h>
 
 static void PrintBootBanner(void);
-static void TestThreadA(void *arg);
-static void TestThreadB(void *arg);
 
 void kmain(BOOT_CAPSULE *capsule);
 
@@ -31,26 +30,7 @@ kmain(BOOT_CAPSULE *capsule)
     InitKernel(capsule);
     PrintBootBanner();
 
-    // Create test kernel threads
-    KTHREAD *threadA = NULL;
-    KTHREAD *threadB = NULL;
-
-    HO_STATUS status;
-    status = KeThreadCreate(&threadA, TestThreadA, (void *)0xAAAA);
-    if (status != EC_SUCCESS)
-        HO_KPANIC(status, "Failed to create thread A");
-
-    status = KeThreadCreate(&threadB, TestThreadB, (void *)0xBBBB);
-    if (status != EC_SUCCESS)
-        HO_KPANIC(status, "Failed to create thread B");
-
-    status = KeThreadStart(threadA);
-    if (status != EC_SUCCESS)
-        HO_KPANIC(status, "Failed to start thread A");
-
-    status = KeThreadStart(threadB);
-    if (status != EC_SUCCESS)
-        HO_KPANIC(status, "Failed to start thread B");
+    RunKernelDemos();
 
     // Query & print initial scheduler state
     KE_SYSINFO_SCHEDULER_DATA schedInfo;
@@ -91,33 +71,4 @@ PrintBootBanner(void)
     kprintf("  %-24s %s\n", "------------------------", "------------------------------------------");
 
     kprintf("Copyright(c) 2024-2025 Himu, ONLY FOR EDUCATIONAL PURPOSES.\n\n");
-}
-
-// ─────────────────────────────────────────────────────────────
-// Test kernel threads
-// ─────────────────────────────────────────────────────────────
-
-static void
-TestThreadA(void *arg)
-{
-    uint32_t id = KeGetCurrentThread()->ThreadId;
-    for (uint32_t i = 0; i < 5; i++)
-    {
-        klog(KLOG_LEVEL_INFO, "[THREAD-%u] tick %u (arg=%p)\n", id, i, arg);
-        KeSleep(50000000ULL); // 50 ms
-    }
-    klog(KLOG_LEVEL_INFO, "[THREAD-%u] done, exiting\n", id);
-}
-
-static void
-TestThreadB(void *arg)
-{
-    uint32_t id = KeGetCurrentThread()->ThreadId;
-    for (uint32_t i = 0; i < 5; i++)
-    {
-        klog(KLOG_LEVEL_INFO, "[THREAD-%u] tick %u (arg=%p)\n", id, i, arg);
-        KeYield();
-        KeSleep(30000000ULL); // 30 ms
-    }
-    klog(KLOG_LEVEL_INFO, "[THREAD-%u] done, exiting\n", id);
 }

--- a/src/kernel/ke/thread/kthread.c
+++ b/src/kernel/ke/thread/kthread.c
@@ -83,10 +83,16 @@ KeThreadCreate(KTHREAD **outThread, KTHREAD_ENTRY entryPoint, void *arg)
 
     thread->Priority = 0;
     thread->Quantum = KE_DEFAULT_QUANTUM_NS;
-    thread->WakeDeadline = 0;
+
+    // Initialize embedded wait block
+    thread->WaitBlock.Dispatcher = NULL;
+    LinkedListInit(&thread->WaitBlock.WaitListLink);
+    LinkedListInit(&thread->WaitBlock.TimeoutLink);
+    thread->WaitBlock.DeadlineNs = 0;
+    thread->WaitBlock.CompletionStatus = EC_SUCCESS;
+    thread->WaitBlock.Completed = FALSE;
 
     LinkedListInit(&thread->ReadyLink);
-    LinkedListInit(&thread->SleepLink);
 
     thread->EntryPoint = entryPoint;
     thread->EntryArg = arg;

--- a/src/kernel/ke/thread/kthread.c
+++ b/src/kernel/ke/thread/kthread.c
@@ -83,6 +83,7 @@ KeThreadCreate(KTHREAD **outThread, KTHREAD_ENTRY entryPoint, void *arg)
 
     thread->Priority = 0;
     thread->Quantum = KE_DEFAULT_QUANTUM_NS;
+    thread->OwnedMutexCount = 0;
 
     // Initialize embedded wait block
     thread->WaitBlock.Dispatcher = NULL;

--- a/src/kernel/ke/thread/scheduler.c
+++ b/src/kernel/ke/thread/scheduler.c
@@ -10,6 +10,7 @@
 #include <kernel/ke/scheduler.h>
 #include <kernel/ke/kthread.h>
 #include <kernel/ke/event.h>
+#include <kernel/ke/mutex.h>
 #include <kernel/ke/semaphore.h>
 #include <kernel/ke/clock_event.h>
 #include <kernel/ke/critical_section.h>
@@ -53,9 +54,16 @@ static uint32_t KiCountQueueDepth(LINKED_LIST_TAG *head);
 static void KiCompleteWait(KWAIT_BLOCK *block, HO_STATUS status);
 static void KiInsertTimeoutQueue(KWAIT_BLOCK *block);
 static void KiInitWaitBlock(KWAIT_BLOCK *block);
+static void KiAssertDispatchContextAllowed(void);
 static HO_STATUS KiValidateDispatcherHeader(const KDISPATCHER_HEADER *header);
+static void KiAssertMutexState(const KMUTEX *mutex);
 static void KiAssertSemaphoreState(const KSEMAPHORE *semaphore);
-static BOOL KiTryAcquireDispatcherObject(KDISPATCHER_HEADER *header);
+static void KiIncrementOwnedMutexCount(KTHREAD *thread);
+static void KiDecrementOwnedMutexCount(KTHREAD *thread);
+static void KiAcquireMutexOwnership(KMUTEX *mutex, KTHREAD *thread);
+static void KiReleaseMutexOwnership(KMUTEX *mutex);
+static void KiHandOffMutexOwnership(KMUTEX *mutex, KTHREAD *thread);
+static HO_STATUS KiTryAcquireDispatcherObject(KDISPATCHER_HEADER *header, KTHREAD *thread, BOOL *acquired);
 
 void KiThreadTrampoline(void);
 
@@ -63,6 +71,12 @@ static inline uint64_t
 KiNowNs(void)
 {
     return KeGetSystemUpRealTime() * 1000ULL;
+}
+
+static void
+KiAssertDispatchContextAllowed(void)
+{
+    HO_KASSERT(KeGetCriticalSectionDepth() == 0, EC_INVALID_STATE);
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -109,6 +123,7 @@ KeSchedulerInit(void)
     gIdleThread->StackPhys = 0; // boot stack, not our allocation
     gIdleThread->Priority = 0;
     gIdleThread->Quantum = 0;
+    gIdleThread->OwnedMutexCount = 0;
     KiInitWaitBlock(&gIdleThread->WaitBlock);
     LinkedListInit(&gIdleThread->ReadyLink);
     gIdleThread->EntryPoint = NULL;
@@ -176,6 +191,8 @@ KeThreadStart(KTHREAD *thread)
 HO_KERNEL_API void
 KeYield(void)
 {
+    KiAssertDispatchContextAllowed();
+
     ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
     KE_CRITICAL_SECTION criticalSection = {0};
     KeEnterCriticalSection(&criticalSection);
@@ -210,6 +227,7 @@ KeSleep(uint64_t durationNs)
         return;
     }
 
+    KiAssertDispatchContextAllowed();
     HO_KASSERT(gCurrentThread != gIdleThread, EC_INVALID_STATE);
 
     ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
@@ -241,11 +259,13 @@ KeSleep(uint64_t durationNs)
 HO_KERNEL_API HO_NORETURN void
 KeThreadExit(void)
 {
+    KiAssertDispatchContextAllowed();
+    HO_KASSERT(gCurrentThread != gIdleThread, EC_INVALID_STATE);
+    HO_KASSERT(gCurrentThread->OwnedMutexCount == 0, EC_INVALID_STATE);
+
     (void)ArchDisableInterrupts();
     KE_CRITICAL_SECTION criticalSection = {0};
     KeEnterCriticalSection(&criticalSection);
-
-    HO_KASSERT(gCurrentThread != gIdleThread, EC_INVALID_STATE);
 
     gCurrentThread->State = KTHREAD_STATE_TERMINATED;
     gStats.ActiveThreadCount--;
@@ -399,9 +419,29 @@ KiValidateDispatcherHeader(const KDISPATCHER_HEADER *header)
     {
     case DISPATCHER_TYPE_EVENT:
     case DISPATCHER_TYPE_SEMAPHORE:
+    case DISPATCHER_TYPE_MUTEX:
         return EC_SUCCESS;
     default:
         return EC_NOT_SUPPORTED;
+    }
+}
+
+// Internal: validate runtime mutex invariants
+static void
+KiAssertMutexState(const KMUTEX *mutex)
+{
+    HO_KASSERT(mutex != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(mutex->Header.Signature == KDISPATCHER_SIGNATURE, EC_INVALID_STATE);
+    HO_KASSERT(mutex->Header.Type == DISPATCHER_TYPE_MUTEX, EC_NOT_SUPPORTED);
+    HO_KASSERT(mutex->Header.SignalState == 0 || mutex->Header.SignalState == 1, EC_INVALID_STATE);
+
+    if (mutex->Header.SignalState != 0)
+    {
+        HO_KASSERT(mutex->OwnerThread == NULL, EC_INVALID_STATE);
+    }
+    else
+    {
+        HO_KASSERT(mutex->OwnerThread != NULL, EC_INVALID_STATE);
     }
 }
 
@@ -417,30 +457,118 @@ KiAssertSemaphoreState(const KSEMAPHORE *semaphore)
     HO_KASSERT(semaphore->Header.SignalState <= semaphore->Limit, EC_INVALID_STATE);
 }
 
-// Internal: test whether a dispatcher object can satisfy immediately.
-// For counted objects, this helper also consumes the permit atomically.
-static BOOL
-KiTryAcquireDispatcherObject(KDISPATCHER_HEADER *header)
+static void
+KiIncrementOwnedMutexCount(KTHREAD *thread)
 {
+    HO_KASSERT(thread != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(thread->OwnedMutexCount != 0xFFFFFFFFU, EC_OUT_OF_RESOURCE);
+    thread->OwnedMutexCount++;
+}
+
+static void
+KiDecrementOwnedMutexCount(KTHREAD *thread)
+{
+    HO_KASSERT(thread != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(thread->OwnedMutexCount != 0, EC_INVALID_STATE);
+    thread->OwnedMutexCount--;
+}
+
+static void
+KiAcquireMutexOwnership(KMUTEX *mutex, KTHREAD *thread)
+{
+    HO_KASSERT(mutex != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(thread != NULL, EC_ILLEGAL_ARGUMENT);
+    KiAssertMutexState(mutex);
+    HO_KASSERT(mutex->Header.SignalState == 1, EC_INVALID_STATE);
+    HO_KASSERT(mutex->OwnerThread == NULL, EC_INVALID_STATE);
+
+    mutex->OwnerThread = thread;
+    mutex->Header.SignalState = 0;
+    KiIncrementOwnedMutexCount(thread);
+    KiAssertMutexState(mutex);
+}
+
+static void
+KiReleaseMutexOwnership(KMUTEX *mutex)
+{
+    KTHREAD *owner;
+
+    HO_KASSERT(mutex != NULL, EC_ILLEGAL_ARGUMENT);
+    KiAssertMutexState(mutex);
+    owner = mutex->OwnerThread;
+    HO_KASSERT(owner != NULL, EC_INVALID_STATE);
+
+    KiDecrementOwnedMutexCount(owner);
+    mutex->OwnerThread = NULL;
+    mutex->Header.SignalState = 1;
+    KiAssertMutexState(mutex);
+}
+
+static void
+KiHandOffMutexOwnership(KMUTEX *mutex, KTHREAD *thread)
+{
+    KTHREAD *owner;
+
+    HO_KASSERT(mutex != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(thread != NULL, EC_ILLEGAL_ARGUMENT);
+    KiAssertMutexState(mutex);
+    owner = mutex->OwnerThread;
+    HO_KASSERT(owner != NULL, EC_INVALID_STATE);
+    HO_KASSERT(owner != thread, EC_INVALID_STATE);
+
+    KiDecrementOwnedMutexCount(owner);
+    mutex->OwnerThread = thread;
+    mutex->Header.SignalState = 0;
+    KiIncrementOwnedMutexCount(thread);
+    KiAssertMutexState(mutex);
+}
+
+// Internal: test whether a dispatcher object can satisfy immediately.
+// For counted or owned objects, this helper also consumes the grant atomically.
+static HO_STATUS
+KiTryAcquireDispatcherObject(KDISPATCHER_HEADER *header, KTHREAD *thread, BOOL *acquired)
+{
+    HO_KASSERT(header != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(acquired != NULL, EC_ILLEGAL_ARGUMENT);
+
+    *acquired = FALSE;
+
     switch (header->Type)
     {
     case DISPATCHER_TYPE_EVENT:
-        return header->SignalState != 0;
+        *acquired = header->SignalState != 0;
+        return EC_SUCCESS;
 
     case DISPATCHER_TYPE_SEMAPHORE: {
         KSEMAPHORE *semaphore = (KSEMAPHORE *)header;
         KiAssertSemaphoreState(semaphore);
 
         if (header->SignalState == 0)
-            return FALSE;
+            return EC_SUCCESS;
 
         header->SignalState--;
         HO_KASSERT(header->SignalState >= 0, EC_INVALID_STATE);
-        return TRUE;
+        *acquired = TRUE;
+        return EC_SUCCESS;
+    }
+
+    case DISPATCHER_TYPE_MUTEX: {
+        KMUTEX *mutex = (KMUTEX *)header;
+        KiAssertMutexState(mutex);
+
+        if (mutex->OwnerThread == thread)
+            return EC_INVALID_STATE;
+
+        if (header->SignalState == 0)
+            return EC_SUCCESS;
+
+        KiAcquireMutexOwnership(mutex, thread);
+        *acquired = TRUE;
+        return EC_SUCCESS;
     }
 
     default:
-        return FALSE;
+        return EC_NOT_SUPPORTED;
     }
 }
 
@@ -575,6 +703,8 @@ KiArmForNextEvent(uint64_t nowNs, KTHREAD *next)
 HO_KERNEL_API HO_STATUS
 KeWaitForSingleObject(void *object, uint64_t timeoutNs)
 {
+    KiAssertDispatchContextAllowed();
+
     if (object == NULL)
         return EC_ILLEGAL_ARGUMENT;
 
@@ -590,7 +720,16 @@ KeWaitForSingleObject(void *object, uint64_t timeoutNs)
     KeEnterCriticalSection(&criticalSection);
 
     // Path 1: object already signaled / has a permit — immediate success
-    if (KiTryAcquireDispatcherObject(header))
+    BOOL acquired = FALSE;
+    HO_STATUS acquireStatus = KiTryAcquireDispatcherObject(header, gCurrentThread, &acquired);
+    if (acquireStatus != EC_SUCCESS)
+    {
+        KeLeaveCriticalSection(&criticalSection);
+        ArchRestoreInterruptState(savedInterruptState);
+        return acquireStatus;
+    }
+
+    if (acquired)
     {
         klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u immediate satisfy (type=%d, state=%ld)\n", gCurrentThread->ThreadId,
              header->Type, (long)header->SignalState);
@@ -743,6 +882,25 @@ KeInitializeSemaphore(KSEMAPHORE *semaphore, int32_t initialCount, int32_t limit
 }
 
 // ─────────────────────────────────────────────────────────────
+// KeInitializeMutex
+// ─────────────────────────────────────────────────────────────
+
+HO_KERNEL_API void
+KeInitializeMutex(KMUTEX *mutex)
+{
+    HO_KASSERT(mutex != NULL, EC_ILLEGAL_ARGUMENT);
+
+    mutex->Header.Signature = KDISPATCHER_SIGNATURE;
+    mutex->Header.Type = DISPATCHER_TYPE_MUTEX;
+    mutex->Header.SignalState = 1;
+    LinkedListInit(&mutex->Header.WaitListHead);
+    mutex->OwnerThread = NULL;
+
+    KiAssertMutexState(mutex);
+    klog(KLOG_LEVEL_DEBUG, "[MUTEX] Initialized (available=1)\n");
+}
+
+// ─────────────────────────────────────────────────────────────
 // KeReleaseSemaphore
 // ─────────────────────────────────────────────────────────────
 
@@ -798,6 +956,51 @@ KeReleaseSemaphore(KSEMAPHORE *semaphore, int32_t releaseCount)
         KiSchedule();
     }
 
+    ArchRestoreInterruptState(savedInterruptState);
+    return EC_SUCCESS;
+}
+
+// ─────────────────────────────────────────────────────────────
+// KeReleaseMutex
+// ─────────────────────────────────────────────────────────────
+
+HO_KERNEL_API HO_STATUS
+KeReleaseMutex(KMUTEX *mutex)
+{
+    if (mutex == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
+    KE_CRITICAL_SECTION criticalSection = {0};
+    KeEnterCriticalSection(&criticalSection);
+
+    KiAssertMutexState(mutex);
+
+    if (mutex->OwnerThread != gCurrentThread)
+    {
+        KeLeaveCriticalSection(&criticalSection);
+        ArchRestoreInterruptState(savedInterruptState);
+        return EC_INVALID_STATE;
+    }
+
+    if (LinkedListIsEmpty(&mutex->Header.WaitListHead))
+    {
+        KiReleaseMutexOwnership(mutex);
+        klog(KLOG_LEVEL_DEBUG, "[MUTEX] Release(owner=%u, handoff=none)\n", gCurrentThread->ThreadId);
+    }
+    else
+    {
+        LINKED_LIST_TAG *entry = mutex->Header.WaitListHead.Flink;
+        KWAIT_BLOCK *block = CONTAINING_RECORD(entry, KWAIT_BLOCK, WaitListLink);
+        KTHREAD *nextOwner = CONTAINING_RECORD(block, KTHREAD, WaitBlock);
+
+        KiHandOffMutexOwnership(mutex, nextOwner);
+        KiCompleteWait(block, EC_SUCCESS);
+        klog(KLOG_LEVEL_DEBUG, "[MUTEX] Release(owner=%u, handoff=%u)\n", gCurrentThread->ThreadId,
+             nextOwner->ThreadId);
+    }
+
+    KeLeaveCriticalSection(&criticalSection);
     ArchRestoreInterruptState(savedInterruptState);
     return EC_SUCCESS;
 }

--- a/src/kernel/ke/thread/scheduler.c
+++ b/src/kernel/ke/thread/scheduler.c
@@ -9,6 +9,7 @@
 
 #include <kernel/ke/scheduler.h>
 #include <kernel/ke/kthread.h>
+#include <kernel/ke/event.h>
 #include <kernel/ke/clock_event.h>
 #include <kernel/ke/critical_section.h>
 #include <kernel/ke/time_source.h>
@@ -25,7 +26,7 @@
 // ─────────────────────────────────────────────────────────────
 
 static LINKED_LIST_TAG gReadyQueue;
-static LINKED_LIST_TAG gSleepQueue;
+static LINKED_LIST_TAG gTimeoutQueue;
 static LINKED_LIST_TAG gTerminatedList;
 
 static KTHREAD *gCurrentThread;
@@ -43,11 +44,15 @@ static uint64_t gNextProgrammedDeadlineNs;
 
 static void KiSchedule(void);
 static void KiSchedulerTimerISR(void *frame, void *context);
-static void KiWakeSleepers(uint64_t nowNs);
+static void KiWakeTimeouts(uint64_t nowNs);
 static void KiArmClockEvent(uint64_t deltaNs);
 static void KiArmForNextEvent(uint64_t nowNs, KTHREAD *next);
 static void KiReapTerminatedThreads(void);
 static uint32_t KiCountQueueDepth(LINKED_LIST_TAG *head);
+static void KiCompleteWait(KWAIT_BLOCK *block, HO_STATUS status);
+static void KiInsertTimeoutQueue(KWAIT_BLOCK *block);
+static void KiInitWaitBlock(KWAIT_BLOCK *block);
+static HO_STATUS KiValidateDispatcherHeader(const KDISPATCHER_HEADER *header);
 
 void KiThreadTrampoline(void);
 
@@ -81,7 +86,7 @@ HO_KERNEL_API HO_STATUS
 KeSchedulerInit(void)
 {
     LinkedListInit(&gReadyQueue);
-    LinkedListInit(&gSleepQueue);
+    LinkedListInit(&gTimeoutQueue);
     LinkedListInit(&gTerminatedList);
     memset(&gStats, 0, sizeof(gStats));
 
@@ -101,9 +106,8 @@ KeSchedulerInit(void)
     gIdleThread->StackPhys = 0; // boot stack, not our allocation
     gIdleThread->Priority = 0;
     gIdleThread->Quantum = 0;
-    gIdleThread->WakeDeadline = 0;
+    KiInitWaitBlock(&gIdleThread->WaitBlock);
     LinkedListInit(&gIdleThread->ReadyLink);
-    LinkedListInit(&gIdleThread->SleepLink);
     gIdleThread->EntryPoint = NULL;
     gIdleThread->EntryArg = NULL;
     gIdleThread->Flags = KTHREAD_FLAG_IDLE;
@@ -210,24 +214,17 @@ KeSleep(uint64_t durationNs)
     KeEnterCriticalSection(&criticalSection);
 
     uint64_t nowNs = KiNowNs();
-    gCurrentThread->WakeDeadline = nowNs + durationNs;
+
+    // Set up timeout-only wait (Dispatcher = NULL)
+    KWAIT_BLOCK *wb = &gCurrentThread->WaitBlock;
+    KiInitWaitBlock(wb);
+    wb->DeadlineNs = nowNs + durationNs;
+
     gCurrentThread->State = KTHREAD_STATE_BLOCKED;
+    KiInsertTimeoutQueue(wb);
 
-    klog(KLOG_LEVEL_DEBUG, "[SCHED] Thread %u sleep %lu ns\n", gCurrentThread->ThreadId, (unsigned long)durationNs);
-
-    // Insert into sleep queue sorted by WakeDeadline (ascending)
-    LINKED_LIST_TAG *pos;
-    for (pos = gSleepQueue.Flink; pos != &gSleepQueue; pos = pos->Flink)
-    {
-        KTHREAD *t = CONTAINING_RECORD(pos, KTHREAD, SleepLink);
-        if (t->WakeDeadline > gCurrentThread->WakeDeadline)
-            break;
-    }
-    // Insert before pos (i.e., at the tail of all entries with earlier deadlines)
-    gCurrentThread->SleepLink.Flink = pos;
-    gCurrentThread->SleepLink.Blink = pos->Blink;
-    pos->Blink->Flink = &gCurrentThread->SleepLink;
-    pos->Blink = &gCurrentThread->SleepLink;
+    klog(KLOG_LEVEL_DEBUG, "[SCHED] Thread %u sleep %lu ns (deadline=%lu)\n", gCurrentThread->ThreadId,
+         (unsigned long)durationNs, (unsigned long)wb->DeadlineNs);
 
     KeLeaveCriticalSection(&criticalSection);
     KiSchedule();
@@ -343,8 +340,8 @@ KiSchedulerTimerISR(void *frame, void *context)
         return;
     }
 
-    // Wake sleeping threads whose deadlines have passed
-    KiWakeSleepers(nowNs);
+    // Wake timed-out wait blocks whose deadlines have passed
+    KiWakeTimeouts(nowNs);
 
     BOOL needReschedule = FALSE;
 
@@ -373,33 +370,102 @@ KiSchedulerTimerISR(void *frame, void *context)
     }
 }
 
-// ─────────────────────────────────────────────────────────────
-// Internal: wake sleeping threads
-// ─────────────────────────────────────────────────────────────
-
+// Internal: initialize a wait block to clean state
 static void
-KiWakeSleepers(uint64_t nowNs)
+KiInitWaitBlock(KWAIT_BLOCK *block)
 {
-    while (!LinkedListIsEmpty(&gSleepQueue))
+    block->Dispatcher = NULL;
+    LinkedListInit(&block->WaitListLink);
+    LinkedListInit(&block->TimeoutLink);
+    block->DeadlineNs = 0;
+    block->CompletionStatus = EC_SUCCESS;
+    block->Completed = FALSE;
+}
+
+// Internal: validate dispatcher headers before generic wait logic
+static HO_STATUS
+KiValidateDispatcherHeader(const KDISPATCHER_HEADER *header)
+{
+    if (header == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (header->Signature != KDISPATCHER_SIGNATURE)
+        return EC_INVALID_STATE;
+
+    switch (header->Type)
     {
-        KTHREAD *sleeper = CONTAINING_RECORD(gSleepQueue.Flink, KTHREAD, SleepLink);
-        if (sleeper->WakeDeadline > nowNs)
-            break;
-
-        LinkedListRemove(&sleeper->SleepLink);
-        sleeper->WakeDeadline = 0;
-        sleeper->State = KTHREAD_STATE_READY;
-        LinkedListInsertTail(&gReadyQueue, &sleeper->ReadyLink);
-        gStats.SleepWakeCount++;
-
-        klog(KLOG_LEVEL_DEBUG, "[SCHED] Thread %u woke up\n", sleeper->ThreadId);
+        case DISPATCHER_TYPE_EVENT:
+            return EC_SUCCESS;
+        default:
+            return EC_NOT_SUPPORTED;
     }
 }
 
-// ─────────────────────────────────────────────────────────────
-// Internal: arm clock event with clamping
-// ─────────────────────────────────────────────────────────────
+// Internal: insert wait block into timeout queue (sorted)
+static void
+KiInsertTimeoutQueue(KWAIT_BLOCK *block)
+{
+    LINKED_LIST_TAG *pos;
+    for (pos = gTimeoutQueue.Flink; pos != &gTimeoutQueue; pos = pos->Flink)
+    {
+        KWAIT_BLOCK *existing = CONTAINING_RECORD(pos, KWAIT_BLOCK, TimeoutLink);
+        if (existing->DeadlineNs > block->DeadlineNs)
+            break;
+    }
+    block->TimeoutLink.Flink = pos;
+    block->TimeoutLink.Blink = pos->Blink;
+    pos->Blink->Flink = &block->TimeoutLink;
+    pos->Blink = &block->TimeoutLink;
+}
 
+// Internal: unified wait completion — signal or timeout
+static void
+KiCompleteWait(KWAIT_BLOCK *block, HO_STATUS status)
+{
+    if (block->Completed)
+        return;
+
+    block->Completed = TRUE;
+    block->CompletionStatus = status;
+
+    // Remove from dispatcher wait list if attached
+    if (block->Dispatcher != NULL)
+    {
+        LinkedListRemove(&block->WaitListLink);
+        LinkedListInit(&block->WaitListLink);
+    }
+
+    // Remove from timeout queue if attached
+    if (block->DeadlineNs != 0)
+    {
+        LinkedListRemove(&block->TimeoutLink);
+        LinkedListInit(&block->TimeoutLink);
+    }
+
+    KTHREAD *thread = CONTAINING_RECORD(block, KTHREAD, WaitBlock);
+    thread->State = KTHREAD_STATE_READY;
+    LinkedListInsertTail(&gReadyQueue, &thread->ReadyLink);
+    gStats.SleepWakeCount++;
+
+    klog(KLOG_LEVEL_DEBUG, "[SCHED] Thread %u wait completed (%s)\n", thread->ThreadId,
+         status == EC_SUCCESS ? "signaled" : "timeout");
+}
+
+// Internal: process timed-out wait blocks
+static void
+KiWakeTimeouts(uint64_t nowNs)
+{
+    while (!LinkedListIsEmpty(&gTimeoutQueue))
+    {
+        KWAIT_BLOCK *block = CONTAINING_RECORD(gTimeoutQueue.Flink, KWAIT_BLOCK, TimeoutLink);
+        if (block->DeadlineNs > nowNs)
+            break;
+
+        KiCompleteWait(block, EC_TIMEOUT);
+    }
+}
+
+// Internal: arm clock event with clamping
 static void
 KiArmClockEvent(uint64_t deltaNs)
 {
@@ -421,21 +487,18 @@ KiArmClockEvent(uint64_t deltaNs)
     }
 }
 
-// ─────────────────────────────────────────────────────────────
 // Internal: compute and arm next event for a thread
-// ─────────────────────────────────────────────────────────────
-
 static void
 KiArmForNextEvent(uint64_t nowNs, KTHREAD *next)
 {
     if (next == gIdleThread)
     {
-        // IdleThread: arm for earliest sleep deadline only
-        if (!LinkedListIsEmpty(&gSleepQueue))
+        // IdleThread: arm for earliest timeout deadline only
+        if (!LinkedListIsEmpty(&gTimeoutQueue))
         {
-            KTHREAD *sleeper = CONTAINING_RECORD(gSleepQueue.Flink, KTHREAD, SleepLink);
-            uint64_t delta = sleeper->WakeDeadline > nowNs ? sleeper->WakeDeadline - nowNs : 1;
-            gNextProgrammedDeadlineNs = sleeper->WakeDeadline;
+            KWAIT_BLOCK *block = CONTAINING_RECORD(gTimeoutQueue.Flink, KWAIT_BLOCK, TimeoutLink);
+            uint64_t delta = block->DeadlineNs > nowNs ? block->DeadlineNs - nowNs : 1;
+            gNextProgrammedDeadlineNs = block->DeadlineNs;
             KiArmClockEvent(delta);
         }
         else
@@ -452,17 +515,168 @@ KiArmForNextEvent(uint64_t nowNs, KTHREAD *next)
 
         uint64_t targetDeadline = gQuantumDeadlineNs;
 
-        if (!LinkedListIsEmpty(&gSleepQueue))
+        if (!LinkedListIsEmpty(&gTimeoutQueue))
         {
-            KTHREAD *sleeper = CONTAINING_RECORD(gSleepQueue.Flink, KTHREAD, SleepLink);
-            if (sleeper->WakeDeadline < targetDeadline)
-                targetDeadline = sleeper->WakeDeadline;
+            KWAIT_BLOCK *block = CONTAINING_RECORD(gTimeoutQueue.Flink, KWAIT_BLOCK, TimeoutLink);
+            if (block->DeadlineNs < targetDeadline)
+                targetDeadline = block->DeadlineNs;
         }
 
         uint64_t delta = targetDeadline > nowNs ? targetDeadline - nowNs : 1;
         gNextProgrammedDeadlineNs = targetDeadline;
         KiArmClockEvent(delta);
     }
+}
+
+// KeWaitForSingleObject
+HO_KERNEL_API HO_STATUS
+KeWaitForSingleObject(void *object, uint64_t timeoutNs)
+{
+    if (object == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    HO_KASSERT(gCurrentThread != gIdleThread, EC_INVALID_STATE);
+
+    KDISPATCHER_HEADER *header = (KDISPATCHER_HEADER *)object;
+    HO_STATUS validationStatus = KiValidateDispatcherHeader(header);
+    if (validationStatus != EC_SUCCESS)
+        return validationStatus;
+
+    ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
+    KE_CRITICAL_SECTION criticalSection = {0};
+    KeEnterCriticalSection(&criticalSection);
+
+    // Path 1: object already signaled — immediate success
+    if (header->SignalState)
+    {
+        klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u immediate satisfy (type=%d)\n", gCurrentThread->ThreadId,
+             header->Type);
+        KeLeaveCriticalSection(&criticalSection);
+        ArchRestoreInterruptState(savedInterruptState);
+        return EC_SUCCESS;
+    }
+
+    // Path 2: zero-timeout poll — immediate timeout
+    if (timeoutNs == 0)
+    {
+        klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u zero-timeout poll miss (type=%d)\n", gCurrentThread->ThreadId,
+             header->Type);
+        KeLeaveCriticalSection(&criticalSection);
+        ArchRestoreInterruptState(savedInterruptState);
+        return EC_TIMEOUT;
+    }
+
+    // Path 3: blocking wait
+    KWAIT_BLOCK *wb = &gCurrentThread->WaitBlock;
+    KiInitWaitBlock(wb);
+    wb->Dispatcher = header;
+
+    // Attach to dispatcher's wait list
+    LinkedListInsertTail(&header->WaitListHead, &wb->WaitListLink);
+
+    // Set up timeout if not infinite
+    if (timeoutNs != KE_WAIT_INFINITE)
+    {
+        uint64_t nowNs = KiNowNs();
+        wb->DeadlineNs = nowNs + timeoutNs;
+        KiInsertTimeoutQueue(wb);
+    }
+
+    gCurrentThread->State = KTHREAD_STATE_BLOCKED;
+
+    klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u blocking (type=%d, timeout=%lu)\n", gCurrentThread->ThreadId, header->Type,
+         (unsigned long)timeoutNs);
+
+    KeLeaveCriticalSection(&criticalSection);
+    KiSchedule();
+
+    HO_STATUS completionStatus = gCurrentThread->WaitBlock.CompletionStatus;
+    klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u resumed (%s)\n", gCurrentThread->ThreadId,
+         completionStatus == EC_SUCCESS ? "signaled" : "timeout");
+    ArchRestoreInterruptState(savedInterruptState);
+
+    return completionStatus;
+}
+
+// ─────────────────────────────────────────────────────────────
+// KeInitializeEvent
+// ─────────────────────────────────────────────────────────────
+
+HO_KERNEL_API void
+KeInitializeEvent(KEVENT *event, BOOL initialState)
+{
+    HO_KASSERT(event != NULL, EC_ILLEGAL_ARGUMENT);
+
+    event->Header.Signature = KDISPATCHER_SIGNATURE;
+    event->Header.Type = DISPATCHER_TYPE_EVENT;
+    event->Header.SignalState = initialState ? 1 : 0;
+    LinkedListInit(&event->Header.WaitListHead);
+
+    klog(KLOG_LEVEL_DEBUG, "[EVENT] Initialized (signaled=%u)\n", (unsigned)initialState);
+}
+
+// ─────────────────────────────────────────────────────────────
+// KeSetEvent
+// ─────────────────────────────────────────────────────────────
+
+HO_KERNEL_API void
+KeSetEvent(KEVENT *event)
+{
+    HO_KASSERT(event != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(event->Header.Signature == KDISPATCHER_SIGNATURE, EC_INVALID_STATE);
+    HO_KASSERT(event->Header.Type == DISPATCHER_TYPE_EVENT, EC_NOT_SUPPORTED);
+
+    ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
+    KE_CRITICAL_SECTION criticalSection = {0};
+    KeEnterCriticalSection(&criticalSection);
+
+    event->Header.SignalState = 1;
+    uint32_t releasedCount = 0;
+
+    // Release all waiters (manual-reset: wake everyone)
+    while (!LinkedListIsEmpty(&event->Header.WaitListHead))
+    {
+        LINKED_LIST_TAG *entry = event->Header.WaitListHead.Flink;
+        KWAIT_BLOCK *block = CONTAINING_RECORD(entry, KWAIT_BLOCK, WaitListLink);
+        KiCompleteWait(block, EC_SUCCESS);
+        releasedCount++;
+    }
+
+    // If CPU is idle and threads became ready, trigger immediate reschedule
+    BOOL needSchedule = (gCurrentThread == gIdleThread && !LinkedListIsEmpty(&gReadyQueue));
+
+    klog(KLOG_LEVEL_DEBUG, "[EVENT] Set (released=%u)\n", releasedCount);
+
+    KeLeaveCriticalSection(&criticalSection);
+
+    if (needSchedule)
+    {
+        klog(KLOG_LEVEL_DEBUG, "[EVENT] Signal during idle, triggering reschedule\n");
+        KiSchedule();
+    }
+
+    ArchRestoreInterruptState(savedInterruptState);
+}
+
+// ─────────────────────────────────────────────────────────────
+// KeResetEvent
+// ─────────────────────────────────────────────────────────────
+
+HO_KERNEL_API void
+KeResetEvent(KEVENT *event)
+{
+    HO_KASSERT(event != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(event->Header.Signature == KDISPATCHER_SIGNATURE, EC_INVALID_STATE);
+    HO_KASSERT(event->Header.Type == DISPATCHER_TYPE_EVENT, EC_NOT_SUPPORTED);
+
+    KE_CRITICAL_SECTION criticalSection = {0};
+    KeEnterCriticalSection(&criticalSection);
+
+    event->Header.SignalState = 0;
+
+    klog(KLOG_LEVEL_DEBUG, "[EVENT] Reset\n");
+
+    KeLeaveCriticalSection(&criticalSection);
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -548,12 +762,12 @@ KeQuerySchedulerInfo(KE_SYSINFO_SCHEDULER_DATA *out)
     out->CurrentThreadId = gCurrentThread ? gCurrentThread->ThreadId : 0;
     out->IdleThreadId = gIdleThread ? gIdleThread->ThreadId : 0;
     out->ReadyQueueDepth = KiCountQueueDepth(&gReadyQueue);
-    out->SleepQueueDepth = KiCountQueueDepth(&gSleepQueue);
+    out->SleepQueueDepth = KiCountQueueDepth(&gTimeoutQueue);
 
-    if (!LinkedListIsEmpty(&gSleepQueue))
+    if (!LinkedListIsEmpty(&gTimeoutQueue))
     {
-        KTHREAD *sleeper = CONTAINING_RECORD(gSleepQueue.Flink, KTHREAD, SleepLink);
-        out->EarliestWakeDeadline = sleeper->WakeDeadline;
+        KWAIT_BLOCK *block = CONTAINING_RECORD(gTimeoutQueue.Flink, KWAIT_BLOCK, TimeoutLink);
+        out->EarliestWakeDeadline = block->DeadlineNs;
     }
 
     out->NextProgrammedDeadline = gNextProgrammedDeadlineNs;

--- a/src/kernel/ke/thread/scheduler.c
+++ b/src/kernel/ke/thread/scheduler.c
@@ -10,6 +10,7 @@
 #include <kernel/ke/scheduler.h>
 #include <kernel/ke/kthread.h>
 #include <kernel/ke/event.h>
+#include <kernel/ke/semaphore.h>
 #include <kernel/ke/clock_event.h>
 #include <kernel/ke/critical_section.h>
 #include <kernel/ke/time_source.h>
@@ -53,6 +54,8 @@ static void KiCompleteWait(KWAIT_BLOCK *block, HO_STATUS status);
 static void KiInsertTimeoutQueue(KWAIT_BLOCK *block);
 static void KiInitWaitBlock(KWAIT_BLOCK *block);
 static HO_STATUS KiValidateDispatcherHeader(const KDISPATCHER_HEADER *header);
+static void KiAssertSemaphoreState(const KSEMAPHORE *semaphore);
+static BOOL KiTryAcquireDispatcherObject(KDISPATCHER_HEADER *header);
 
 void KiThreadTrampoline(void);
 
@@ -394,10 +397,50 @@ KiValidateDispatcherHeader(const KDISPATCHER_HEADER *header)
 
     switch (header->Type)
     {
-        case DISPATCHER_TYPE_EVENT:
-            return EC_SUCCESS;
-        default:
-            return EC_NOT_SUPPORTED;
+    case DISPATCHER_TYPE_EVENT:
+    case DISPATCHER_TYPE_SEMAPHORE:
+        return EC_SUCCESS;
+    default:
+        return EC_NOT_SUPPORTED;
+    }
+}
+
+// Internal: validate runtime semaphore invariants
+static void
+KiAssertSemaphoreState(const KSEMAPHORE *semaphore)
+{
+    HO_KASSERT(semaphore != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(semaphore->Header.Signature == KDISPATCHER_SIGNATURE, EC_INVALID_STATE);
+    HO_KASSERT(semaphore->Header.Type == DISPATCHER_TYPE_SEMAPHORE, EC_NOT_SUPPORTED);
+    HO_KASSERT(semaphore->Limit > 0, EC_INVALID_STATE);
+    HO_KASSERT(semaphore->Header.SignalState >= 0, EC_INVALID_STATE);
+    HO_KASSERT(semaphore->Header.SignalState <= semaphore->Limit, EC_INVALID_STATE);
+}
+
+// Internal: test whether a dispatcher object can satisfy immediately.
+// For counted objects, this helper also consumes the permit atomically.
+static BOOL
+KiTryAcquireDispatcherObject(KDISPATCHER_HEADER *header)
+{
+    switch (header->Type)
+    {
+    case DISPATCHER_TYPE_EVENT:
+        return header->SignalState != 0;
+
+    case DISPATCHER_TYPE_SEMAPHORE: {
+        KSEMAPHORE *semaphore = (KSEMAPHORE *)header;
+        KiAssertSemaphoreState(semaphore);
+
+        if (header->SignalState == 0)
+            return FALSE;
+
+        header->SignalState--;
+        HO_KASSERT(header->SignalState >= 0, EC_INVALID_STATE);
+        return TRUE;
+    }
+
+    default:
+        return FALSE;
     }
 }
 
@@ -546,11 +589,11 @@ KeWaitForSingleObject(void *object, uint64_t timeoutNs)
     KE_CRITICAL_SECTION criticalSection = {0};
     KeEnterCriticalSection(&criticalSection);
 
-    // Path 1: object already signaled — immediate success
-    if (header->SignalState)
+    // Path 1: object already signaled / has a permit — immediate success
+    if (KiTryAcquireDispatcherObject(header))
     {
-        klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u immediate satisfy (type=%d)\n", gCurrentThread->ThreadId,
-             header->Type);
+        klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u immediate satisfy (type=%d, state=%ld)\n", gCurrentThread->ThreadId,
+             header->Type, (long)header->SignalState);
         KeLeaveCriticalSection(&criticalSection);
         ArchRestoreInterruptState(savedInterruptState);
         return EC_SUCCESS;
@@ -559,8 +602,8 @@ KeWaitForSingleObject(void *object, uint64_t timeoutNs)
     // Path 2: zero-timeout poll — immediate timeout
     if (timeoutNs == 0)
     {
-        klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u zero-timeout poll miss (type=%d)\n", gCurrentThread->ThreadId,
-             header->Type);
+        klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u zero-timeout poll miss (type=%d, state=%ld)\n",
+             gCurrentThread->ThreadId, header->Type, (long)header->SignalState);
         KeLeaveCriticalSection(&criticalSection);
         ArchRestoreInterruptState(savedInterruptState);
         return EC_TIMEOUT;
@@ -677,6 +720,86 @@ KeResetEvent(KEVENT *event)
     klog(KLOG_LEVEL_DEBUG, "[EVENT] Reset\n");
 
     KeLeaveCriticalSection(&criticalSection);
+}
+
+// ─────────────────────────────────────────────────────────────
+// KeInitializeSemaphore
+// ─────────────────────────────────────────────────────────────
+
+HO_KERNEL_API HO_STATUS
+KeInitializeSemaphore(KSEMAPHORE *semaphore, int32_t initialCount, int32_t limit)
+{
+    if (semaphore == NULL || initialCount < 0 || limit <= 0 || initialCount > limit)
+        return EC_ILLEGAL_ARGUMENT;
+
+    semaphore->Header.Signature = KDISPATCHER_SIGNATURE;
+    semaphore->Header.Type = DISPATCHER_TYPE_SEMAPHORE;
+    semaphore->Header.SignalState = initialCount;
+    LinkedListInit(&semaphore->Header.WaitListHead);
+    semaphore->Limit = limit;
+
+    klog(KLOG_LEVEL_DEBUG, "[SEMAPHORE] Initialized (count=%ld, limit=%ld)\n", (long)initialCount, (long)limit);
+    return EC_SUCCESS;
+}
+
+// ─────────────────────────────────────────────────────────────
+// KeReleaseSemaphore
+// ─────────────────────────────────────────────────────────────
+
+HO_KERNEL_API HO_STATUS
+KeReleaseSemaphore(KSEMAPHORE *semaphore, int32_t releaseCount)
+{
+    if (semaphore == NULL || releaseCount <= 0)
+        return EC_ILLEGAL_ARGUMENT;
+
+    ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
+    KE_CRITICAL_SECTION criticalSection = {0};
+    KeEnterCriticalSection(&criticalSection);
+
+    KiAssertSemaphoreState(semaphore);
+
+    uint32_t waiterCount = KiCountQueueDepth(&semaphore->Header.WaitListHead);
+    int64_t remainingPermitCount =
+        releaseCount > (int32_t)waiterCount ? (int64_t)releaseCount - (int64_t)waiterCount : 0;
+    int64_t resultingCount = (int64_t)semaphore->Header.SignalState + remainingPermitCount;
+
+    if (resultingCount > semaphore->Limit)
+    {
+        KeLeaveCriticalSection(&criticalSection);
+        ArchRestoreInterruptState(savedInterruptState);
+        return EC_ILLEGAL_ARGUMENT;
+    }
+
+    int32_t permitsToDispatch = releaseCount;
+    uint32_t releasedWaiters = 0;
+
+    while (permitsToDispatch > 0 && !LinkedListIsEmpty(&semaphore->Header.WaitListHead))
+    {
+        LINKED_LIST_TAG *entry = semaphore->Header.WaitListHead.Flink;
+        KWAIT_BLOCK *block = CONTAINING_RECORD(entry, KWAIT_BLOCK, WaitListLink);
+        KiCompleteWait(block, EC_SUCCESS);
+        permitsToDispatch--;
+        releasedWaiters++;
+    }
+
+    semaphore->Header.SignalState += permitsToDispatch;
+    KiAssertSemaphoreState(semaphore);
+
+    BOOL needSchedule = (gCurrentThread == gIdleThread && !LinkedListIsEmpty(&gReadyQueue));
+
+    klog(KLOG_LEVEL_DEBUG, "[SEMAPHORE] Release(count=%ld, woke=%u, available=%ld)\n", (long)releaseCount,
+         releasedWaiters, (long)semaphore->Header.SignalState);
+
+    KeLeaveCriticalSection(&criticalSection);
+
+    if (needSchedule)
+    {
+        klog(KLOG_LEVEL_DEBUG, "[SEMAPHORE] Release during idle, triggering reschedule\n");
+        KiSchedule();
+    }
+
+    ArchRestoreInterruptState(savedInterruptState);
+    return EC_SUCCESS;
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR implements a complete KMUTEX (kernel mutex) object for the unified dispatcher-based wait model, featuring owner tracking, hand-off semantics, and safety guards against common concurrency bugs.

## Changes

### Core KMUTEX Implementation
- **New header**: `src/include/kernel/ke/mutex.h` - KMUTEX structure and API
- **Initialization**: `KeInitializeMutex()` - creates mutex in signaled state (available)
- **Release**: `KeReleaseMutex()` - owner-only release with automatic handoff to waiters

### Ownership & Safety
- **Owner tracking**: KMUTEX records the owning KTHREAD pointer
- **Recursive acquire prevention**: Returns `EC_INVALID_STATE` if owner tries to re-acquire
- **Non-owner release prevention**: Returns `EC_INVALID_STATE` if non-owner attempts release
- **Ownership handoff**: Direct transfer to first waiter without intermediate signaling

### Thread Safety Guards
- **Critical section protection**: `KiAssertDispatchContextAllowed()` ensures no dispatch operations inside critical sections
- **Exit validation**: `KeThreadExit()` now panics if thread owns any mutexes (`OwnedMutexCount > 0`)

### Demo & Testing
- Unified `make test schedule` runs all dispatcher demos (thread, event, semaphore, mutex)
- Added mutex demo: owner, poller, waiters, non-owner release attempts
- Added safety regression tests:
  - Guard-wait violation: waiting inside critical section
  - Owned-exit violation: exiting while holding mutex

## Verification

```bash
# Build and run full demo suite
make test schedule

# Expected output includes:
# - [MUTOWNER] immediate acquire (expect SUCCESS)
# - [MUTOWNER] self-acquire (expect EC_INVALID_STATE)
# - [MUTPOLL] zero-timeout poll (expect TIMEOUT)
# - [MUTEX] Release with handoff semantics
```

## Design Notes

- KMUTEX integrates seamlessly with existing `KeWaitForSingleObject()` API
- Wait blocks use FIFO ordering for fairness
- Hand-off semantics prevent starvation and reduce context switches
- Zero changes to public dispatcher API - fully backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)