### PR TITLE
feat(ke): implement IRQL management and integrate into critical sections and thread handling

### DIFF
--- a/makefile
+++ b/makefile
@@ -78,20 +78,26 @@ KRN_BUILDROOT := build/kernel$(if $(strip $(BUILD_FLAVOR)),/$(BUILD_FLAVOR),)
 KRN_OBJDIR    := $(KRN_BUILDROOT)/obj
 KRN_BINDIR    := $(KRN_BUILDROOT)/bin
 
-VALID_TEST_MODULES := schedule list
+VALID_TEST_MODULES := schedule guard_wait owned_exit irql_wait irql_sleep irql_yield irql_exit list
 TEST_MODULE_GOALS  := $(filter-out test,$(MAKECMDGOALS))
 TEST_MODULE        := $(if $(strip $(TEST_MODULE_GOALS)),$(firstword $(TEST_MODULE_GOALS)),list)
 TEST_BUILD_FLAVOR  := test-$(TEST_MODULE)
 
 TEST_DEFINE_schedule := HO_DEMO_TEST_SCHEDULE
+TEST_DEFINE_guard_wait := HO_DEMO_TEST_GUARD_WAIT
+TEST_DEFINE_owned_exit := HO_DEMO_TEST_OWNED_EXIT
+TEST_DEFINE_irql_wait := HO_DEMO_TEST_IRQL_WAIT
+TEST_DEFINE_irql_sleep := HO_DEMO_TEST_IRQL_SLEEP
+TEST_DEFINE_irql_yield := HO_DEMO_TEST_IRQL_YIELD
+TEST_DEFINE_irql_exit := HO_DEMO_TEST_IRQL_EXIT
 
 ifneq ($(filter test,$(MAKECMDGOALS)),)
 ifneq ($(words $(TEST_MODULE_GOALS)),0)
 ifneq ($(words $(TEST_MODULE_GOALS)),1)
-$(error Usage: make test <module>. Available modules: schedule. Use `make test` or `make test list` to inspect supported modules)
+$(error Usage: make test <module>. Available modules: schedule, guard_wait, owned_exit, irql_wait, irql_sleep, irql_yield, irql_exit. Use `make test` or `make test list` to inspect supported modules)
 endif
 ifneq ($(filter $(TEST_MODULE),$(VALID_TEST_MODULES)), $(TEST_MODULE))
-$(error Unknown test module '$(TEST_MODULE)'. Available modules: schedule. Use `make test list` to inspect supported modules)
+$(error Unknown test module '$(TEST_MODULE)'. Available modules: schedule, guard_wait, owned_exit, irql_wait, irql_sleep, irql_yield, irql_exit. Use `make test list` to inspect supported modules)
 endif
 endif
 endif
@@ -159,6 +165,7 @@ SRCS_KERNEL_C := \
     src/kernel/hodbg.c                                  \
     src/kernel/demo.c                                   \
     src/kernel/ke/critical_section.c                    \
+    src/kernel/ke/irql.c                                \
     src/kernel/ke/console/console.c                     \
     src/kernel/ke/console/console_device.c              \
     src/kernel/ke/console/sinks/gfx_console_sink.c      \
@@ -273,8 +280,15 @@ test:
 ifeq ($(TEST_MODULE),list)
 	@echo "Available test modules:"
 	@echo "  schedule - scheduler demo suite (previous make run / make test all behavior)"
+	@echo "  guard_wait - panic demo: wait while holding a critical section"
+	@echo "  owned_exit - panic demo: exit while owning a mutex"
+	@echo "  irql_wait  - panic demo: zero-timeout wait while holding DISPATCH_LEVEL guard"
+	@echo "  irql_sleep - panic demo: sleep while holding DISPATCH_LEVEL guard"
+	@echo "  irql_yield - panic demo: yield while holding DISPATCH_LEVEL guard"
+	@echo "  irql_exit  - panic demo: thread exit while holding DISPATCH_LEVEL guard"
 	@echo "Usage:"
 	@echo "  make test schedule   # run the scheduler demo suite"
+	@echo "  make test irql_wait  # run a dispatch-guard misuse panic regression"
 	@echo "  make test            # list available test modules"
 else
 	@echo "Starting test module: $(TEST_MODULE)"

--- a/src/arch/amd64/idt.c
+++ b/src/arch/amd64/idt.c
@@ -1,6 +1,7 @@
 #include "arch/amd64/idt.h"
 #include "arch/amd64/pm.h"
 #include "kernel/hodbg.h"
+#include <kernel/ke/irql.h>
 #include <libc/string.h>
 
 static IDT_ENTRY kInterruptDescriptorTable[256];
@@ -90,7 +91,9 @@ IdtExceptionHandler(void *frame)
         return;
     }
 
+    KeEnterInterruptContext();
     HandleExternalInterrupt(dump);
+    KeLeaveInterruptContext();
 }
 
 HO_PUBLIC_API const char *

--- a/src/include/kernel/ke/critical_section.h
+++ b/src/include/kernel/ke/critical_section.h
@@ -10,11 +10,11 @@
 #pragma once
 
 #include <_hobase.h>
-#include <arch/arch.h>
+#include <kernel/ke/irql.h>
 
 typedef struct KE_CRITICAL_SECTION
 {
-    ARCH_INTERRUPT_STATE SavedInterruptState;
+    KE_IRQL_GUARD IrqlGuard;
     uint32_t EnterDepth;
     BOOL Active;
 } KE_CRITICAL_SECTION;

--- a/src/include/kernel/ke/irql.h
+++ b/src/include/kernel/ke/irql.h
@@ -1,0 +1,48 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/irql.h
+ * Description:
+ * Ke Layer - Minimal IRQL / execution-level model for UP scheduling paths.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <_hobase.h>
+#include <arch/arch.h>
+
+typedef enum KE_IRQL
+{
+    KE_IRQL_PASSIVE_LEVEL = 0,
+    KE_IRQL_DISPATCH_LEVEL = 1,
+} KE_IRQL;
+
+typedef struct KE_IRQL_STATE
+{
+    KE_IRQL CurrentLevel;
+    uint32_t DispatchDepth;
+    uint32_t InterruptDepth;
+} KE_IRQL_STATE;
+
+typedef struct KE_IRQL_GUARD
+{
+    BOOL Active;
+    BOOL Transitioned;
+    ARCH_INTERRUPT_STATE SavedInterruptState;
+    KE_IRQL PreviousLevel;
+    KE_IRQL TargetLevel;
+    uint32_t EnterDepth;
+} KE_IRQL_GUARD;
+
+HO_KERNEL_API void KeInitializeIrqlState(KE_IRQL_STATE *state);
+HO_KERNEL_API void KeSetCurrentIrqlState(KE_IRQL_STATE *state);
+
+HO_KERNEL_API KE_IRQL KeGetCurrentIrql(void);
+HO_KERNEL_API BOOL KeIsBlockingAllowed(void);
+
+HO_KERNEL_API void KeAcquireIrqlGuard(KE_IRQL_GUARD *guard, KE_IRQL targetLevel);
+HO_KERNEL_API void KeReleaseIrqlGuard(KE_IRQL_GUARD *guard);
+
+HO_KERNEL_API void KeEnterInterruptContext(void);
+HO_KERNEL_API void KeLeaveInterruptContext(void);

--- a/src/include/kernel/ke/kthread.h
+++ b/src/include/kernel/ke/kthread.h
@@ -12,6 +12,7 @@
 #include <_hobase.h>
 #include <lib/common/linked_list.h>
 #include <kernel/ke/pool.h>
+#include <kernel/ke/irql.h>
 #include <kernel/ke/dispatcher.h>
 
 // ─────────────────────────────────────────────────────────────
@@ -68,6 +69,7 @@ typedef struct KTHREAD
     uint8_t Priority; // Reserved for multi-priority extension
     uint64_t Quantum; // Time slice remaining (nanoseconds)
     uint32_t OwnedMutexCount;
+    KE_IRQL_STATE IrqlState;
 
     KWAIT_BLOCK WaitBlock; // Embedded wait record for unified wait model
 

--- a/src/kernel/demo.c
+++ b/src/kernel/demo.c
@@ -12,6 +12,7 @@
 #include <kernel/ke/scheduler.h>
 #include <kernel/ke/kthread.h>
 #include <kernel/ke/critical_section.h>
+#include <kernel/ke/irql.h>
 #include <kernel/ke/event.h>
 #include <kernel/ke/mutex.h>
 #include <kernel/ke/semaphore.h>
@@ -24,6 +25,10 @@
 #define HO_DEMO_TEST_MUTEX      5
 #define HO_DEMO_TEST_GUARD_WAIT 6
 #define HO_DEMO_TEST_OWNED_EXIT 7
+#define HO_DEMO_TEST_IRQL_WAIT  8
+#define HO_DEMO_TEST_IRQL_SLEEP 9
+#define HO_DEMO_TEST_IRQL_YIELD 10
+#define HO_DEMO_TEST_IRQL_EXIT  11
 
 #ifndef HO_DEMO_TEST_SELECTION
 #define HO_DEMO_TEST_SELECTION HO_DEMO_TEST_NONE
@@ -52,13 +57,19 @@ static void MutexWaiterTwoThread(void *arg);
 static void MutexNonOwnerReleaseThread(void *arg);
 static void CriticalSectionWaitViolationThread(void *arg);
 static void OwnedMutexExitViolationThread(void *arg);
+static void DispatchGuardWaitViolationThread(void *arg);
+static void DispatchGuardSleepViolationThread(void *arg);
+static void DispatchGuardYieldViolationThread(void *arg);
+static void DispatchGuardExitViolationThread(void *arg);
 
 static KEVENT gTestEvent;
 static KSEMAPHORE gTestSemaphore;
 static KMUTEX gTestMutex;
 static KEVENT gCriticalSectionGuardEvent;
+static KEVENT gDispatchGuardEvent;
 static KMUTEX gOwnedExitMutex;
 
+static void RunIrqlSelfTest(void);
 static void RunScheduleDemo(void);
 static void RunThreadDemo(void);
 static void RunEventDemo(void);
@@ -66,6 +77,10 @@ static void RunSemaphoreDemo(void);
 static void RunMutexDemo(void);
 static void RunGuardWaitDemo(void);
 static void RunOwnedExitDemo(void);
+static void RunDispatchGuardWaitDemo(void);
+static void RunDispatchGuardSleepDemo(void);
+static void RunDispatchGuardYieldDemo(void);
+static void RunDispatchGuardExitDemo(void);
 
 void
 RunKernelDemos(void)
@@ -112,15 +127,81 @@ RunKernelDemos(void)
     {
         RunOwnedExitDemo();
     }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_IRQL_WAIT)
+    {
+        RunDispatchGuardWaitDemo();
+    }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_IRQL_SLEEP)
+    {
+        RunDispatchGuardSleepDemo();
+    }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_IRQL_YIELD)
+    {
+        RunDispatchGuardYieldDemo();
+    }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_IRQL_EXIT)
+    {
+        RunDispatchGuardExitDemo();
+    }
 }
 
 static void
 RunScheduleDemo(void)
 {
+    RunIrqlSelfTest();
     RunThreadDemo();
     RunEventDemo();
     RunSemaphoreDemo();
     RunMutexDemo();
+}
+
+static void
+RunIrqlSelfTest(void)
+{
+    KE_IRQL_GUARD outerGuard = {0};
+    KE_IRQL_GUARD innerGuard = {0};
+    KE_CRITICAL_SECTION outerCriticalSection = {0};
+    KE_CRITICAL_SECTION innerCriticalSection = {0};
+
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_PASSIVE_LEVEL, EC_INVALID_STATE);
+    HO_KASSERT(KeIsBlockingAllowed(), EC_INVALID_STATE);
+
+    KeAcquireIrqlGuard(&outerGuard, KE_IRQL_DISPATCH_LEVEL);
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_DISPATCH_LEVEL, EC_INVALID_STATE);
+    HO_KASSERT(!KeIsBlockingAllowed(), EC_INVALID_STATE);
+
+    KeAcquireIrqlGuard(&innerGuard, KE_IRQL_DISPATCH_LEVEL);
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_DISPATCH_LEVEL, EC_INVALID_STATE);
+    HO_KASSERT(!KeIsBlockingAllowed(), EC_INVALID_STATE);
+    KeReleaseIrqlGuard(&innerGuard);
+
+    KeEnterCriticalSection(&outerCriticalSection);
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_DISPATCH_LEVEL, EC_INVALID_STATE);
+    KeLeaveCriticalSection(&outerCriticalSection);
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_DISPATCH_LEVEL, EC_INVALID_STATE);
+
+    KeReleaseIrqlGuard(&outerGuard);
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_PASSIVE_LEVEL, EC_INVALID_STATE);
+    HO_KASSERT(KeIsBlockingAllowed(), EC_INVALID_STATE);
+
+    KeEnterCriticalSection(&outerCriticalSection);
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_DISPATCH_LEVEL, EC_INVALID_STATE);
+    HO_KASSERT(!KeIsBlockingAllowed(), EC_INVALID_STATE);
+
+    KeEnterCriticalSection(&innerCriticalSection);
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_DISPATCH_LEVEL, EC_INVALID_STATE);
+    KeLeaveCriticalSection(&innerCriticalSection);
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_DISPATCH_LEVEL, EC_INVALID_STATE);
+
+    KeLeaveCriticalSection(&outerCriticalSection);
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_PASSIVE_LEVEL, EC_INVALID_STATE);
+    HO_KASSERT(KeIsBlockingAllowed(), EC_INVALID_STATE);
+
+    klog(KLOG_LEVEL_INFO, "[DEMO] IRQL/critical-section self-test passed\n");
 }
 
 static void
@@ -343,6 +424,68 @@ RunOwnedExitDemo(void)
     status = KeThreadStart(violator);
     if (status != EC_SUCCESS)
         HO_KPANIC(status, "Failed to start owned-exit violation thread");
+}
+
+static void
+RunDispatchGuardWaitDemo(void)
+{
+    HO_STATUS status;
+    KTHREAD *violator = NULL;
+
+    KeInitializeEvent(&gDispatchGuardEvent, TRUE);
+
+    status = KeThreadCreate(&violator, DispatchGuardWaitViolationThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create dispatch-guard wait violation thread");
+
+    status = KeThreadStart(violator);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start dispatch-guard wait violation thread");
+}
+
+static void
+RunDispatchGuardSleepDemo(void)
+{
+    HO_STATUS status;
+    KTHREAD *violator = NULL;
+
+    status = KeThreadCreate(&violator, DispatchGuardSleepViolationThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create dispatch-guard sleep violation thread");
+
+    status = KeThreadStart(violator);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start dispatch-guard sleep violation thread");
+}
+
+static void
+RunDispatchGuardYieldDemo(void)
+{
+    HO_STATUS status;
+    KTHREAD *violator = NULL;
+
+    status = KeThreadCreate(&violator, DispatchGuardYieldViolationThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create dispatch-guard yield violation thread");
+
+    status = KeThreadStart(violator);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start dispatch-guard yield violation thread");
+}
+
+static void
+RunDispatchGuardExitDemo(void)
+{
+    HO_STATUS status;
+    KTHREAD *violator = NULL;
+
+    status = KeThreadCreate(&violator, DispatchGuardExitViolationThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create dispatch-guard exit violation thread");
+
+    status = KeThreadStart(violator);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start dispatch-guard exit violation thread");
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -655,4 +798,60 @@ OwnedMutexExitViolationThread(void *arg)
 
     klog(KLOG_LEVEL_INFO, "[OWNEDEXIT-%u] calling KeThreadExit while owning mutex (expect panic)\n", id);
     KeThreadExit();
+}
+
+static void
+DispatchGuardWaitViolationThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+    KE_IRQL_GUARD irqlGuard = {0};
+
+    klog(KLOG_LEVEL_INFO, "[IRQLWAIT-%u] entering DISPATCH_LEVEL before wait (expect panic)\n", id);
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
+
+    (void)KeWaitForSingleObject(&gDispatchGuardEvent, 0);
+    HO_KPANIC(EC_INVALID_STATE, "Dispatch-guard wait legality check did not fire");
+}
+
+static void
+DispatchGuardSleepViolationThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+    KE_IRQL_GUARD irqlGuard = {0};
+
+    klog(KLOG_LEVEL_INFO, "[IRQLSLEEP-%u] entering DISPATCH_LEVEL before sleep (expect panic)\n", id);
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
+
+    KeSleep(1000000ULL);
+    HO_KPANIC(EC_INVALID_STATE, "Dispatch-guard sleep legality check did not fire");
+}
+
+static void
+DispatchGuardYieldViolationThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+    KE_IRQL_GUARD irqlGuard = {0};
+
+    klog(KLOG_LEVEL_INFO, "[IRQLYIELD-%u] entering DISPATCH_LEVEL before yield (expect panic)\n", id);
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
+
+    KeYield();
+    HO_KPANIC(EC_INVALID_STATE, "Dispatch-guard yield legality check did not fire");
+}
+
+static void
+DispatchGuardExitViolationThread(void *arg)
+{
+    (void)arg;
+    uint32_t id = KeGetCurrentThread()->ThreadId;
+    KE_IRQL_GUARD irqlGuard = {0};
+
+    klog(KLOG_LEVEL_INFO, "[IRQLEXIT-%u] entering DISPATCH_LEVEL before exit (expect panic)\n", id);
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
+
+    KeThreadExit();
+    HO_KPANIC(EC_INVALID_STATE, "Dispatch-guard thread-exit legality check did not fire");
 }

--- a/src/kernel/ke/critical_section.c
+++ b/src/kernel/ke/critical_section.c
@@ -19,7 +19,7 @@ KeEnterCriticalSection(KE_CRITICAL_SECTION *guard)
     HO_KASSERT(!guard->Active, EC_INVALID_STATE);
     HO_KASSERT(gCriticalSectionDepth != 0xFFFFFFFFU, EC_OUT_OF_RESOURCE);
 
-    guard->SavedInterruptState = ArchDisableInterrupts();
+    KeAcquireIrqlGuard(&guard->IrqlGuard, KE_IRQL_DISPATCH_LEVEL);
     gCriticalSectionDepth++;
 
     guard->EnterDepth = gCriticalSectionDepth;
@@ -35,13 +35,11 @@ KeLeaveCriticalSection(KE_CRITICAL_SECTION *guard)
     HO_KASSERT(guard->EnterDepth == gCriticalSectionDepth, EC_INVALID_STATE);
 
     gCriticalSectionDepth--;
-    BOOL restoreInterrupts = (gCriticalSectionDepth == 0) && guard->SavedInterruptState.MaskableInterruptEnabled;
 
     guard->Active = FALSE;
     guard->EnterDepth = 0;
 
-    if (restoreInterrupts)
-        ArchRestoreInterruptState(guard->SavedInterruptState);
+    KeReleaseIrqlGuard(&guard->IrqlGuard);
 }
 
 HO_KERNEL_API uint32_t

--- a/src/kernel/ke/irql.c
+++ b/src/kernel/ke/irql.c
@@ -1,0 +1,170 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/irql.c
+ * Description:
+ * Ke Layer - Minimal IRQL / execution-level bookkeeping for UP scheduling.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#include <kernel/ke/irql.h>
+#include <kernel/hodbg.h>
+
+static KE_IRQL_STATE gBootstrapIrqlState = {
+    .CurrentLevel = KE_IRQL_PASSIVE_LEVEL,
+    .DispatchDepth = 0,
+    .InterruptDepth = 0,
+};
+
+static KE_IRQL_STATE *gCurrentIrqlState = &gBootstrapIrqlState;
+
+static KE_IRQL_STATE *
+KiGetCurrentIrqlState(void)
+{
+    HO_KASSERT(gCurrentIrqlState != NULL, EC_INVALID_STATE);
+    return gCurrentIrqlState;
+}
+
+static void
+KiAssertIrqlState(const KE_IRQL_STATE *state)
+{
+    HO_KASSERT(state != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(state->InterruptDepth <= state->DispatchDepth, EC_INVALID_STATE);
+
+    if (state->DispatchDepth == 0)
+    {
+        HO_KASSERT(state->CurrentLevel == KE_IRQL_PASSIVE_LEVEL, EC_INVALID_STATE);
+    }
+    else
+    {
+        HO_KASSERT(state->CurrentLevel == KE_IRQL_DISPATCH_LEVEL, EC_INVALID_STATE);
+    }
+}
+
+HO_KERNEL_API void
+KeInitializeIrqlState(KE_IRQL_STATE *state)
+{
+    HO_KASSERT(state != NULL, EC_ILLEGAL_ARGUMENT);
+
+    state->CurrentLevel = KE_IRQL_PASSIVE_LEVEL;
+    state->DispatchDepth = 0;
+    state->InterruptDepth = 0;
+}
+
+HO_KERNEL_API void
+KeSetCurrentIrqlState(KE_IRQL_STATE *state)
+{
+    HO_KASSERT(state != NULL, EC_ILLEGAL_ARGUMENT);
+    KiAssertIrqlState(state);
+    gCurrentIrqlState = state;
+}
+
+HO_KERNEL_API KE_IRQL
+KeGetCurrentIrql(void)
+{
+    KE_IRQL_STATE *state = KiGetCurrentIrqlState();
+    KiAssertIrqlState(state);
+    return state->CurrentLevel;
+}
+
+HO_KERNEL_API BOOL
+KeIsBlockingAllowed(void)
+{
+    return KeGetCurrentIrql() == KE_IRQL_PASSIVE_LEVEL;
+}
+
+HO_KERNEL_API void
+KeAcquireIrqlGuard(KE_IRQL_GUARD *guard, KE_IRQL targetLevel)
+{
+    KE_IRQL_STATE *state = KiGetCurrentIrqlState();
+
+    HO_KASSERT(guard != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(!guard->Active, EC_INVALID_STATE);
+    HO_KASSERT(targetLevel == KE_IRQL_DISPATCH_LEVEL, EC_NOT_SUPPORTED);
+    HO_KASSERT(state->DispatchDepth != 0xFFFFFFFFU, EC_OUT_OF_RESOURCE);
+
+    KiAssertIrqlState(state);
+
+    guard->SavedInterruptState = (ARCH_INTERRUPT_STATE){0};
+    guard->PreviousLevel = state->CurrentLevel;
+    guard->TargetLevel = targetLevel;
+    guard->Transitioned = FALSE;
+
+    if (state->CurrentLevel == KE_IRQL_PASSIVE_LEVEL)
+    {
+        guard->SavedInterruptState = ArchDisableInterrupts();
+        guard->Transitioned = TRUE;
+    }
+
+    state->DispatchDepth++;
+    state->CurrentLevel = KE_IRQL_DISPATCH_LEVEL;
+
+    guard->EnterDepth = state->DispatchDepth;
+    guard->Active = TRUE;
+
+    KiAssertIrqlState(state);
+}
+
+HO_KERNEL_API void
+KeReleaseIrqlGuard(KE_IRQL_GUARD *guard)
+{
+    KE_IRQL_STATE *state = KiGetCurrentIrqlState();
+
+    HO_KASSERT(guard != NULL, EC_ILLEGAL_ARGUMENT);
+    HO_KASSERT(guard->Active, EC_INVALID_STATE);
+    HO_KASSERT(guard->TargetLevel == KE_IRQL_DISPATCH_LEVEL, EC_NOT_SUPPORTED);
+
+    KiAssertIrqlState(state);
+    HO_KASSERT(state->DispatchDepth != 0, EC_INVALID_STATE);
+    HO_KASSERT(guard->EnterDepth == state->DispatchDepth, EC_INVALID_STATE);
+
+    state->DispatchDepth--;
+    state->CurrentLevel = state->DispatchDepth == 0 ? guard->PreviousLevel : KE_IRQL_DISPATCH_LEVEL;
+
+    guard->Active = FALSE;
+    guard->EnterDepth = 0;
+    guard->TargetLevel = KE_IRQL_PASSIVE_LEVEL;
+
+    if (guard->Transitioned)
+    {
+        HO_KASSERT(state->DispatchDepth == 0, EC_INVALID_STATE);
+        ArchRestoreInterruptState(guard->SavedInterruptState);
+    }
+
+    guard->Transitioned = FALSE;
+
+    KiAssertIrqlState(state);
+}
+
+HO_KERNEL_API void
+KeEnterInterruptContext(void)
+{
+    KE_IRQL_STATE *state = KiGetCurrentIrqlState();
+
+    KiAssertIrqlState(state);
+    HO_KASSERT(state->DispatchDepth != 0xFFFFFFFFU, EC_OUT_OF_RESOURCE);
+    HO_KASSERT(state->InterruptDepth != 0xFFFFFFFFU, EC_OUT_OF_RESOURCE);
+
+    state->DispatchDepth++;
+    state->InterruptDepth++;
+    state->CurrentLevel = KE_IRQL_DISPATCH_LEVEL;
+
+    KiAssertIrqlState(state);
+}
+
+HO_KERNEL_API void
+KeLeaveInterruptContext(void)
+{
+    KE_IRQL_STATE *state = KiGetCurrentIrqlState();
+
+    KiAssertIrqlState(state);
+    HO_KASSERT(state->InterruptDepth != 0, EC_INVALID_STATE);
+    HO_KASSERT(state->DispatchDepth != 0, EC_INVALID_STATE);
+    HO_KASSERT(state->DispatchDepth == state->InterruptDepth, EC_INVALID_STATE);
+
+    state->InterruptDepth--;
+    state->DispatchDepth--;
+    state->CurrentLevel = state->DispatchDepth == 0 ? KE_IRQL_PASSIVE_LEVEL : KE_IRQL_DISPATCH_LEVEL;
+
+    KiAssertIrqlState(state);
+}

--- a/src/kernel/ke/thread/kthread.c
+++ b/src/kernel/ke/thread/kthread.c
@@ -8,6 +8,7 @@
  */
 
 #include <kernel/ke/kthread.h>
+#include <kernel/ke/irql.h>
 #include <kernel/ke/scheduler.h>
 #include <kernel/ke/mm.h>
 #include <kernel/hodefs.h>
@@ -84,6 +85,7 @@ KeThreadCreate(KTHREAD **outThread, KTHREAD_ENTRY entryPoint, void *arg)
     thread->Priority = 0;
     thread->Quantum = KE_DEFAULT_QUANTUM_NS;
     thread->OwnedMutexCount = 0;
+    KeInitializeIrqlState(&thread->IrqlState);
 
     // Initialize embedded wait block
     thread->WaitBlock.Dispatcher = NULL;

--- a/src/kernel/ke/thread/scheduler.c
+++ b/src/kernel/ke/thread/scheduler.c
@@ -14,6 +14,7 @@
 #include <kernel/ke/semaphore.h>
 #include <kernel/ke/clock_event.h>
 #include <kernel/ke/critical_section.h>
+#include <kernel/ke/irql.h>
 #include <kernel/ke/time_source.h>
 #include <kernel/ke/mm.h>
 #include <kernel/hodefs.h>
@@ -54,7 +55,8 @@ static uint32_t KiCountQueueDepth(LINKED_LIST_TAG *head);
 static void KiCompleteWait(KWAIT_BLOCK *block, HO_STATUS status);
 static void KiInsertTimeoutQueue(KWAIT_BLOCK *block);
 static void KiInitWaitBlock(KWAIT_BLOCK *block);
-static void KiAssertDispatchContextAllowed(void);
+static void KiAssertBlockingAllowed(void);
+static void KiAssertDispatchLevel(void);
 static HO_STATUS KiValidateDispatcherHeader(const KDISPATCHER_HEADER *header);
 static void KiAssertMutexState(const KMUTEX *mutex);
 static void KiAssertSemaphoreState(const KSEMAPHORE *semaphore);
@@ -74,9 +76,15 @@ KiNowNs(void)
 }
 
 static void
-KiAssertDispatchContextAllowed(void)
+KiAssertBlockingAllowed(void)
 {
-    HO_KASSERT(KeGetCriticalSectionDepth() == 0, EC_INVALID_STATE);
+    HO_KASSERT(KeIsBlockingAllowed(), EC_INVALID_STATE);
+}
+
+static void
+KiAssertDispatchLevel(void)
+{
+    HO_KASSERT(KeGetCurrentIrql() == KE_IRQL_DISPATCH_LEVEL, EC_INVALID_STATE);
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -124,6 +132,7 @@ KeSchedulerInit(void)
     gIdleThread->Priority = 0;
     gIdleThread->Quantum = 0;
     gIdleThread->OwnedMutexCount = 0;
+    KeInitializeIrqlState(&gIdleThread->IrqlState);
     KiInitWaitBlock(&gIdleThread->WaitBlock);
     LinkedListInit(&gIdleThread->ReadyLink);
     gIdleThread->EntryPoint = NULL;
@@ -131,6 +140,7 @@ KeSchedulerInit(void)
     gIdleThread->Flags = KTHREAD_FLAG_IDLE;
 
     gCurrentThread = gIdleThread;
+    KeSetCurrentIrqlState(&gIdleThread->IrqlState);
     gStats.TotalThreadsCreated = 1;
     gStats.ActiveThreadCount = 1;
 
@@ -191,9 +201,10 @@ KeThreadStart(KTHREAD *thread)
 HO_KERNEL_API void
 KeYield(void)
 {
-    KiAssertDispatchContextAllowed();
+    KiAssertBlockingAllowed();
 
-    ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
+    KE_IRQL_GUARD irqlGuard = {0};
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
     KE_CRITICAL_SECTION criticalSection = {0};
     KeEnterCriticalSection(&criticalSection);
 
@@ -202,7 +213,7 @@ KeYield(void)
     if (LinkedListIsEmpty(&gReadyQueue))
     {
         KeLeaveCriticalSection(&criticalSection);
-        ArchRestoreInterruptState(savedInterruptState);
+        KeReleaseIrqlGuard(&irqlGuard);
         return;
     }
 
@@ -211,7 +222,7 @@ KeYield(void)
 
     KeLeaveCriticalSection(&criticalSection);
     KiSchedule();
-    ArchRestoreInterruptState(savedInterruptState);
+    KeReleaseIrqlGuard(&irqlGuard);
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -221,16 +232,18 @@ KeYield(void)
 HO_KERNEL_API void
 KeSleep(uint64_t durationNs)
 {
+    KiAssertBlockingAllowed();
+
     if (durationNs == 0)
     {
         KeYield();
         return;
     }
 
-    KiAssertDispatchContextAllowed();
     HO_KASSERT(gCurrentThread != gIdleThread, EC_INVALID_STATE);
 
-    ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
+    KE_IRQL_GUARD irqlGuard = {0};
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
     KE_CRITICAL_SECTION criticalSection = {0};
     KeEnterCriticalSection(&criticalSection);
 
@@ -249,7 +262,7 @@ KeSleep(uint64_t durationNs)
 
     KeLeaveCriticalSection(&criticalSection);
     KiSchedule();
-    ArchRestoreInterruptState(savedInterruptState);
+    KeReleaseIrqlGuard(&irqlGuard);
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -259,11 +272,12 @@ KeSleep(uint64_t durationNs)
 HO_KERNEL_API HO_NORETURN void
 KeThreadExit(void)
 {
-    KiAssertDispatchContextAllowed();
+    KiAssertBlockingAllowed();
     HO_KASSERT(gCurrentThread != gIdleThread, EC_INVALID_STATE);
     HO_KASSERT(gCurrentThread->OwnedMutexCount == 0, EC_INVALID_STATE);
 
-    (void)ArchDisableInterrupts();
+    KE_IRQL_GUARD irqlGuard = {0};
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
     KE_CRITICAL_SECTION criticalSection = {0};
     KeEnterCriticalSection(&criticalSection);
 
@@ -297,7 +311,7 @@ KeGetCurrentThread(void)
 static void
 KiSchedule(void)
 {
-    // Must be called with IF=0
+    KiAssertDispatchLevel();
 
     KTHREAD *prev = gCurrentThread;
     KTHREAD *next;
@@ -315,6 +329,8 @@ KiSchedule(void)
 
     if (next == prev)
     {
+        next->State = KTHREAD_STATE_RUNNING;
+
         // Same thread, just re-arm and continue
         uint64_t nowNs = KiNowNs();
         KiArmForNextEvent(nowNs, next);
@@ -322,7 +338,6 @@ KiSchedule(void)
     }
 
     next->State = KTHREAD_STATE_RUNNING;
-    gCurrentThread = next;
     gStats.ContextSwitchCount++;
 
     // Update TSS.RSP0 to target thread's kernel stack top
@@ -334,6 +349,9 @@ KiSchedule(void)
     // Arm clock event for next deadline
     uint64_t nowNs = KiNowNs();
     KiArmForNextEvent(nowNs, next);
+
+    gCurrentThread = next;
+    KeSetCurrentIrqlState(&next->IrqlState);
 
     // Context switch — does not return until this thread is resumed
     KiSwitchContext(&prev->Context, &next->Context);
@@ -353,6 +371,8 @@ KiSchedulerTimerISR(void *frame, void *context)
 
     if (!gSchedulerEnabled)
         return;
+
+    KiAssertDispatchLevel();
 
     uint64_t nowNs = KiNowNs();
 
@@ -703,7 +723,7 @@ KiArmForNextEvent(uint64_t nowNs, KTHREAD *next)
 HO_KERNEL_API HO_STATUS
 KeWaitForSingleObject(void *object, uint64_t timeoutNs)
 {
-    KiAssertDispatchContextAllowed();
+    KiAssertBlockingAllowed();
 
     if (object == NULL)
         return EC_ILLEGAL_ARGUMENT;
@@ -715,7 +735,8 @@ KeWaitForSingleObject(void *object, uint64_t timeoutNs)
     if (validationStatus != EC_SUCCESS)
         return validationStatus;
 
-    ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
+    KE_IRQL_GUARD irqlGuard = {0};
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
     KE_CRITICAL_SECTION criticalSection = {0};
     KeEnterCriticalSection(&criticalSection);
 
@@ -725,7 +746,7 @@ KeWaitForSingleObject(void *object, uint64_t timeoutNs)
     if (acquireStatus != EC_SUCCESS)
     {
         KeLeaveCriticalSection(&criticalSection);
-        ArchRestoreInterruptState(savedInterruptState);
+        KeReleaseIrqlGuard(&irqlGuard);
         return acquireStatus;
     }
 
@@ -734,7 +755,7 @@ KeWaitForSingleObject(void *object, uint64_t timeoutNs)
         klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u immediate satisfy (type=%d, state=%ld)\n", gCurrentThread->ThreadId,
              header->Type, (long)header->SignalState);
         KeLeaveCriticalSection(&criticalSection);
-        ArchRestoreInterruptState(savedInterruptState);
+        KeReleaseIrqlGuard(&irqlGuard);
         return EC_SUCCESS;
     }
 
@@ -744,7 +765,7 @@ KeWaitForSingleObject(void *object, uint64_t timeoutNs)
         klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u zero-timeout poll miss (type=%d, state=%ld)\n",
              gCurrentThread->ThreadId, header->Type, (long)header->SignalState);
         KeLeaveCriticalSection(&criticalSection);
-        ArchRestoreInterruptState(savedInterruptState);
+        KeReleaseIrqlGuard(&irqlGuard);
         return EC_TIMEOUT;
     }
 
@@ -775,7 +796,7 @@ KeWaitForSingleObject(void *object, uint64_t timeoutNs)
     HO_STATUS completionStatus = gCurrentThread->WaitBlock.CompletionStatus;
     klog(KLOG_LEVEL_DEBUG, "[WAIT] Thread %u resumed (%s)\n", gCurrentThread->ThreadId,
          completionStatus == EC_SUCCESS ? "signaled" : "timeout");
-    ArchRestoreInterruptState(savedInterruptState);
+    KeReleaseIrqlGuard(&irqlGuard);
 
     return completionStatus;
 }
@@ -808,7 +829,8 @@ KeSetEvent(KEVENT *event)
     HO_KASSERT(event->Header.Signature == KDISPATCHER_SIGNATURE, EC_INVALID_STATE);
     HO_KASSERT(event->Header.Type == DISPATCHER_TYPE_EVENT, EC_NOT_SUPPORTED);
 
-    ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
+    KE_IRQL_GUARD irqlGuard = {0};
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
     KE_CRITICAL_SECTION criticalSection = {0};
     KeEnterCriticalSection(&criticalSection);
 
@@ -837,7 +859,7 @@ KeSetEvent(KEVENT *event)
         KiSchedule();
     }
 
-    ArchRestoreInterruptState(savedInterruptState);
+    KeReleaseIrqlGuard(&irqlGuard);
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -910,7 +932,8 @@ KeReleaseSemaphore(KSEMAPHORE *semaphore, int32_t releaseCount)
     if (semaphore == NULL || releaseCount <= 0)
         return EC_ILLEGAL_ARGUMENT;
 
-    ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
+    KE_IRQL_GUARD irqlGuard = {0};
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
     KE_CRITICAL_SECTION criticalSection = {0};
     KeEnterCriticalSection(&criticalSection);
 
@@ -924,7 +947,7 @@ KeReleaseSemaphore(KSEMAPHORE *semaphore, int32_t releaseCount)
     if (resultingCount > semaphore->Limit)
     {
         KeLeaveCriticalSection(&criticalSection);
-        ArchRestoreInterruptState(savedInterruptState);
+        KeReleaseIrqlGuard(&irqlGuard);
         return EC_ILLEGAL_ARGUMENT;
     }
 
@@ -956,7 +979,7 @@ KeReleaseSemaphore(KSEMAPHORE *semaphore, int32_t releaseCount)
         KiSchedule();
     }
 
-    ArchRestoreInterruptState(savedInterruptState);
+    KeReleaseIrqlGuard(&irqlGuard);
     return EC_SUCCESS;
 }
 
@@ -970,7 +993,8 @@ KeReleaseMutex(KMUTEX *mutex)
     if (mutex == NULL)
         return EC_ILLEGAL_ARGUMENT;
 
-    ARCH_INTERRUPT_STATE savedInterruptState = ArchDisableInterrupts();
+    KE_IRQL_GUARD irqlGuard = {0};
+    KeAcquireIrqlGuard(&irqlGuard, KE_IRQL_DISPATCH_LEVEL);
     KE_CRITICAL_SECTION criticalSection = {0};
     KeEnterCriticalSection(&criticalSection);
 
@@ -979,7 +1003,7 @@ KeReleaseMutex(KMUTEX *mutex)
     if (mutex->OwnerThread != gCurrentThread)
     {
         KeLeaveCriticalSection(&criticalSection);
-        ArchRestoreInterruptState(savedInterruptState);
+        KeReleaseIrqlGuard(&irqlGuard);
         return EC_INVALID_STATE;
     }
 
@@ -1001,7 +1025,7 @@ KeReleaseMutex(KMUTEX *mutex)
     }
 
     KeLeaveCriticalSection(&criticalSection);
-    ArchRestoreInterruptState(savedInterruptState);
+    KeReleaseIrqlGuard(&irqlGuard);
     return EC_SUCCESS;
 }
 


### PR DESCRIPTION
## Summary

This PR introduces a minimal IRQL (Interrupt Request Level) management system inspired by the Windows kernel model. IRQL provides a foundation for controlling execution levels in the kernel, enabling proper synchronization and preventing blocking operations in inappropriate contexts.

## Changes

### New Files
- `src/include/kernel/ke/irql.h` - IRQL types and API declarations
- `src/kernel/ke/irql.c` - IRQL implementation with:
  - Two IRQL levels: `PASSIVE_LEVEL` (0) and `DISPATCH_LEVEL` (1)
  - IRQL guard mechanism for safe level transitions
  - Interrupt context tracking (Enter/Leave)
  - Blocking validation (`KeIsBlockingAllowed()`)

### Modified Files
- `critical_section.c/h` - Migrated to use `KE_IRQL_GUARD` instead of raw interrupt state
- `scheduler.c` - Added `KiAssertBlockingAllowed()` and `KiAssertDispatchLevel()` helpers
- `kthread.c/h` - Added `IrqlState` to KTHREAD for per-thread IRQL tracking
- `idt.c` - Integrated `KeEnterInterruptContext()` / `KeLeaveInterruptContext()` in ISR path
- `demo.c` - Added IRQL demo scenarios
- `Makefile` - Added `irql.o` to build

## IRQL Model

```
PASSIVE_LEVEL (0)  - Normal thread execution, blocking allowed
DISPATCH_LEVEL (1) - Dispatcher/ISR context, blocking prohibited
```

## Key APIs

| Function | Purpose |
|----------|---------|
| `KeAcquireIrqlGuard()` | Raise to DISPATCH_LEVEL, disable interrupts if needed |
| `KeReleaseIrqlGuard()` | Restore previous IRQL, re-enable interrupts |
| `KeGetCurrentIrql()` | Query current IRQL level |
| `KeIsBlockingAllowed()` | Check if current context permits blocking |
| `KeEnterInterruptContext()` | Mark entry to interrupt handler |
| `KeLeaveInterruptContext()` | Mark exit from interrupt handler |

## Safety Features

- **Depth tracking**: Supports nested IRQL raises (with depth counters)
- **State validation**: Assertions verify IRQL state consistency
- **Automatic restoration**: IRQL guards ensure proper cleanup via `Transitioned` flag
- **Thread affinity**: Each KTHREAD has its own `KE_IRQL_STATE`

## Testing

- IRQL guards properly nest
- Critical sections integrate with IRQL
- Scheduler asserts block only at PASSIVE_LEVEL
- Interrupt handlers correctly enter/leave context

## Related Commits

Based on dispatcher object work from:
- `feat(ke): implement unified wait model with dispatcher objects`
- `feat(ke): add semaphore support`
- `feat(ke): implement KMUTEX with ownership tracking`