### PR TITLE
[codex] synchronize kthread pool allocation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,6 +39,58 @@
 | 显示器    | 支持彩色的文本界面                                 |
 | 设备支持   | 标准 VGA 显示器、标准QWERTY键盘输入支持；MMIO 支持         |
 
+## 回归 profile 与推荐执行流程
+
+HimuOS 当前把内核 demo/test profile 视为稳定的 regression profile。推荐流程始终是：
+
+```bash
+make clean
+bear -- make all BUILD_FLAVOR=<flavor> HO_DEMO_TEST_NAME=<profile> HO_DEMO_TEST_DEFINE=<define>
+
+BUILD_FLAVOR=<flavor> HO_DEMO_TEST_NAME=<profile> HO_DEMO_TEST_DEFINE=<define> \
+    bash scripts/qemu_capture.sh 30 /tmp/himuos-<profile>.log
+```
+
+其中 `scripts/qemu_capture.sh` 是主运行与串口捕获入口；不要把隐式 `make run` 或 `make test` 当作默认验证路径。
+
+### 稳定 profile 标识符
+
+| Profile | Build flavor | Define | Outcome class | Intent |
+| ------ | ------ | ------ | ------ | ------ |
+| `schedule` | `test-schedule` | `HO_DEMO_TEST_SCHEDULE` | clean pass with continued boot/idle | scheduler smoke coverage, thread/event/semaphore/mutex 基线路径 |
+| `guard_wait` | `test-guard_wait` | `HO_DEMO_TEST_GUARD_WAIT` | diagnosable contract violation or panic | critical-section guard misuse |
+| `owned_exit` | `test-owned_exit` | `HO_DEMO_TEST_OWNED_EXIT` | diagnosable contract violation or panic | exit while owning a mutex |
+| `irql_wait` | `test-irql_wait` | `HO_DEMO_TEST_IRQL_WAIT` | diagnosable contract violation or panic | wait at `DISPATCH_LEVEL` |
+| `irql_sleep` | `test-irql_sleep` | `HO_DEMO_TEST_IRQL_SLEEP` | diagnosable contract violation or panic | sleep at `DISPATCH_LEVEL` |
+| `irql_yield` | `test-irql_yield` | `HO_DEMO_TEST_IRQL_YIELD` | diagnosable contract violation or panic | yield at `DISPATCH_LEVEL` |
+| `irql_exit` | `test-irql_exit` | `HO_DEMO_TEST_IRQL_EXIT` | diagnosable contract violation or panic | thread exit at `DISPATCH_LEVEL` |
+| `pf_imported` | `test-pf_imported` | `HO_DEMO_TEST_PF_IMPORTED` | intentional fatal page-fault halt with bounded diagnostics | imported kernel-data NX fault diagnosis |
+| `pf_guard` | `test-pf_guard` | `HO_DEMO_TEST_PF_GUARD` | intentional fatal page-fault halt with bounded diagnostics | stack guard-page diagnosis |
+| `pf_fixmap` | `test-pf_fixmap` | `HO_DEMO_TEST_PF_FIXMAP` | intentional fatal page-fault halt with bounded diagnostics | active fixmap alias diagnosis |
+| `pf_heap` | `test-pf_heap` | `HO_DEMO_TEST_PF_HEAP` | intentional fatal page-fault halt with bounded diagnostics | heap-backed KVA diagnosis |
+
+### 例子
+
+```bash
+# clean-pass profile
+make clean
+bear -- make all BUILD_FLAVOR=test-schedule HO_DEMO_TEST_NAME=schedule HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_SCHEDULE
+BUILD_FLAVOR=test-schedule HO_DEMO_TEST_NAME=schedule HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_SCHEDULE \
+    bash scripts/qemu_capture.sh 30 /tmp/himuos-schedule.log
+
+# guard-misuse profile
+make clean
+bear -- make all BUILD_FLAVOR=test-guard_wait HO_DEMO_TEST_NAME=guard_wait HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_GUARD_WAIT
+BUILD_FLAVOR=test-guard_wait HO_DEMO_TEST_NAME=guard_wait HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_GUARD_WAIT \
+    bash scripts/qemu_capture.sh 30 /tmp/himuos-guard-wait.log
+
+# page-fault profile
+make clean
+bear -- make all BUILD_FLAVOR=test-pf_guard HO_DEMO_TEST_NAME=pf_guard HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_PF_GUARD
+BUILD_FLAVOR=test-pf_guard HO_DEMO_TEST_NAME=pf_guard HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_PF_GUARD \
+    bash scripts/qemu_capture.sh 30 /tmp/himuos-pf-guard.log
+```
+
 ## 版权与许可
 
 本项目遵循 GNU 通用公共许可证 (GPL) 第 3 版或更高版本发布。您可以自由地使用、修改和分发本项目的代码。

--- a/docs/apis/KeQuerySystemInformation.md
+++ b/docs/apis/KeQuerySystemInformation.md
@@ -41,6 +41,7 @@ HO_STATUS HO_KERNEL_API KeQuerySystemInformation(
 | `KE_SYSINFO_CLOCK_EVENT` | SYSINFO_CLOCK_EVENT | 当前时钟事件设备状态 |
 | `KE_SYSINFO_SCHEDULER` | KE_SYSINFO_SCHEDULER_DATA | 调度器状态快照 |
 | `KE_SYSINFO_VMM_OVERVIEW` | SYSINFO_VMM_OVERVIEW | VMM 总览（imported/KVA/fixmap） |
+| `KE_SYSINFO_ACTIVE_KVA_RANGES` | SYSINFO_ACTIVE_KVA_RANGES | 活跃 KVA range 的有界快照 |
 
 ## 返回结构体
 
@@ -108,6 +109,85 @@ typedef struct SYSINFO_VMM_OVERVIEW {
 - `ActiveKvaRangeCount/Fixmap*` 来自 `KeKvaQueryUsageInfo()`。
 - 若地址空间或 KVA 尚未初始化，查询返回 `EC_INVALID_STATE`。
 
+### SYSINFO_ACTIVE_KVA_RANGES
+
+```c
+#define SYSINFO_ACTIVE_KVA_RANGE_MAX 16U
+
+typedef struct SYSINFO_ACTIVE_KVA_RANGE {
+    KE_KVA_ARENA_TYPE Arena;
+    uint32_t RecordId;
+    uint64_t Generation;
+    HO_VIRTUAL_ADDRESS BaseAddress;
+    HO_VIRTUAL_ADDRESS EndAddressExclusive;
+    HO_VIRTUAL_ADDRESS UsableBase;
+    HO_VIRTUAL_ADDRESS UsableEndExclusive;
+    uint64_t TotalPages;
+    uint64_t UsablePages;
+    uint64_t GuardLowerPages;
+    uint64_t GuardUpperPages;
+} SYSINFO_ACTIVE_KVA_RANGE;
+
+typedef struct SYSINFO_ACTIVE_KVA_RANGES {
+    uint64_t TotalActiveRangeCount;
+    uint32_t ReturnedRangeCount;
+    BOOL Truncated;
+    SYSINFO_ACTIVE_KVA_RANGE Ranges[SYSINFO_ACTIVE_KVA_RANGE_MAX];
+} SYSINFO_ACTIVE_KVA_RANGES;
+```
+
+说明：
+- 该查询返回一个固定上限为 `16` 条记录的稳定快照，用 arena 与虚拟地址范围语义描述当前活跃 KVA range。
+- `RecordId + 64-bit Generation` 共同标识当前这一次 live range 实例；仅凭 `RecordId` 不能跨释放/复用周期充当稳定所有权句柄。
+- `TotalActiveRangeCount` 表示系统中当前活跃 range 总数，`ReturnedRangeCount` 表示本次快照实际返回条数。
+- 当活跃 range 多于快照容量时，`Truncated == TRUE`，调用者必须把它解释为“有更多活跃 range 未被当前快照承载”，而不是“不存在更多 range”。
+- KVA 未初始化时该查询返回 `EC_INVALID_STATE`；它不会输出部分伪造记录。
+
+### SYSINFO_CLOCK_EVENT
+
+```c
+typedef struct SYSINFO_CLOCK_EVENT {
+    BOOL Ready;
+    uint64_t FreqHz;
+    uint64_t InterruptCount;
+    uint64_t MinDeltaNs;
+    uint64_t MaxDeltaNs;
+    uint8_t VectorNumber;
+    char SourceName[SYSINFO_TIME_SOURCE_NAME_LEN];
+} SYSINFO_CLOCK_EVENT;
+```
+
+说明：
+- `Ready == FALSE` 时，查询仍返回 `EC_SUCCESS`，但不会伪造 source/vector/frequency 或 one-shot envelope。
+- `MinDeltaNs/MaxDeltaNs` 描述活动 clock-event 设备当前支持的 one-shot 编程边界。
+- scheduler 自己打算驱动的下一次 deadline 仍通过 `KE_SYSINFO_SCHEDULER.NextProgrammedDeadline` 查询，而不是塞回 clock-event 设备快照。
+
+### KE_SYSINFO_SCHEDULER_DATA
+
+```c
+typedef struct KE_SYSINFO_SCHEDULER_DATA {
+    BOOL SchedulerEnabled;
+    uint32_t CurrentThreadId;
+    uint32_t IdleThreadId;
+    uint32_t ReadyQueueDepth;
+    uint32_t SleepQueueDepth;
+    uint32_t ActiveThreadCount;
+    uint64_t EarliestWakeDeadline;
+    uint64_t NextProgrammedDeadline;
+    uint64_t ContextSwitchCount;
+    uint64_t PreemptionCount;
+    uint64_t YieldCount;
+    uint64_t SleepWakeCount;
+    uint64_t TotalThreadsCreated;
+} KE_SYSINFO_SCHEDULER_DATA;
+```
+
+说明：
+- `SleepQueueDepth` 表示全局 timeout-backed queue 的深度，覆盖 `KeSleep()` 和带有限 deadline 的 dispatcher wait。
+- `EarliestWakeDeadline` 是 timeout queue 队首最早绝对 deadline；无等待项时为 `0`。
+- `NextProgrammedDeadline` 反映 scheduler 当前打算驱动的下一次绝对 deadline；系统真正 idle 且无 timeout-backed wait 时为 `0`。
+- `SleepWakeCount` 统计 timeout 路径唤醒次数，不把对象 signal 立即满足计入 timeout 唤醒。
+
 ### SYSINFO_UPTIME
 
 ```c
@@ -131,15 +211,18 @@ typedef struct SYSINFO_UPTIME {
 以下接口不属于 `KeQuerySystemInformation`，但与本次内存可观测性变更配套：
 
 - `KeDiagnoseVirtualAddress()`：组合 imported-region、PT query、KVA 分类及各层状态，返回统一的 `KE_VA_DIAGNOSIS`。
-- 页故障蓝屏输出：在 vector-14 下始终先输出寄存器转储、`CR2` 与 `PFERR` 位域；只有进入 dedicated `IST2` 安全诊断上下文后，才追加 `VMM imported / VMM pt / VMM kva` 三层诊断，用于区分 imported 地址、guard page、active fixmap、active heap 或未映射空洞。
+- 页故障蓝屏输出：在 vector-14 下始终先输出寄存器转储、`CR2` 与 `PFERR` 位域；只有进入 dedicated `IST2` 安全诊断上下文后，才追加 `VMM imported / VMM pt / VMM kva` 三层诊断。若某层不可用，输出会显式标示 `unavailable`，而不是猜测成功分类。
 
 ## 启动期联动验证
 
-`InitKernel` 中新增 `RunMemoryObservabilitySelfTest()`，会在启动时验证：
+`InitKernel` 中的 observability self-test 会在启动时验证：
 
 1. `KE_SYSINFO_PHYSICAL_MEM_STATS` 与 `KE_SYSINFO_VMM_OVERVIEW` 可成功查询并建立基线。
-2. 临时 fixmap 映射与 heap 分配会推动 PMM/VMM 计数按预期变化。
-3. 资源释放后计数回归基线，确保无泄漏和账本漂移。
+2. `KE_SYSINFO_ACTIVE_KVA_RANGES` 能以有界快照方式反映 fixmap 与 heap 的真实活跃 range，并在需要时通过 `Truncated` 表达省略。
+3. 临时 fixmap 映射与 heap 分配会推动 PMM/VMM 计数按预期变化。
+4. clock-event 就绪后，`KE_SYSINFO_CLOCK_EVENT` 会暴露 source/vector/frequency 与有效的 `MinDeltaNs/MaxDeltaNs` 编程边界。
+5. scheduler 初始化后，`KE_SYSINFO_SCHEDULER` 会反映 idle 基线：`CurrentThreadId == IdleThreadId == 0`、无 ready/sleep backlog、无 pending deadline。
+6. 资源释放后计数回归基线，确保无泄漏和账本漂移。
 
 ## 使用示例
 

--- a/docs/design/ke-mm.md
+++ b/docs/design/ke-mm.md
@@ -233,13 +233,13 @@ KVA 的内部账本由两部分组成：
 当前 fixmap 路径是：
 
 1. `KeFixmapAcquire()`
-   从 fixmap arena 保留 1 页 KVA range，并把指定物理页映射进去。
+   从 fixmap arena 保留 1 页 KVA range，并把指定物理页映射进去；返回的是可用于 release 的 opaque handle，而不是可长期缓存的裸 slot。
 2. `KeTempPhysMapAcquire()`
-   再在上层包一层 opaque handle，避免调用方直接持有 slot 编号。
+   当前只是对同一 fixmap-handle 语义的专用命名包装，强调“这是运行期 RAM 的短生命周期 alias”。
 3. `KeTempPhysMapRelease()`
-   基于 token 中编码的 slot + generation 安全回收临时映射。
+   基于 token 中编码的 slot + 64-bit generation 安全回收临时映射。
 
-`generation` 追踪是本分支最后一个提交补上的能力，它让“旧 handle 释放了新一轮复用的 slot”这种 ABA 风险被显式拒绝。
+`generation` 追踪采用“单调递增、耗尽即拒绝继续复用”的策略，它让“旧 handle 释放了新一轮复用的 slot”这种 ABA 风险被显式拒绝，而不是仅仅推迟到 wraparound 之后。
 
 当前语义是：
 
@@ -287,7 +287,7 @@ heap 目前还不是 malloc/slab，而是页级接口：
    - `StackSize`
    - `StackGuardBase`
    - `StackOwnedByKva`
-4. 线程退出回收时，通过 `KeKvaReleaseRange(thread->StackBase)` 一次性回收栈虚拟区间与其物理 backing。
+4. `KTHREAD` 还保留原始 `StackRange` handle，线程退出回收时通过 `KeKvaReleaseRangeHandle(&thread->StackRange)` 一次性回收栈虚拟区间与其物理 backing。
 
 这一步的意义很大：
 
@@ -307,6 +307,8 @@ heap 目前还不是 malloc/slab，而是页级接口：
   返回 PMM 的 `Total/Free/Allocated/Reserved` 四元统计。
 - `KE_SYSINFO_VMM_OVERVIEW`
   返回 imported region 数量、stack/fixmap/heap 三个 arena 的总页数/空闲页数/活跃分配数，以及活跃 range 数和 fixmap 槽位使用量。
+- `KE_SYSINFO_ACTIVE_KVA_RANGES`
+  返回一个固定上限、显式 `Truncated` 的活跃 KVA range 快照，使用稳定的 arena/虚拟地址区间语义承载当前 stack、fixmap、heap-backed range。
 
 这样内存系统开始具备统一可查询的状态面，而不再只依赖零散日志。
 
@@ -314,13 +316,15 @@ heap 目前还不是 malloc/slab，而是页级接口：
 
 `RunMemoryObservabilitySelfTest()` 会联动验证：
 
-1. 先读取 PMM/VMM 基线统计。
+1. 先读取 PMM/VMM 基线统计与 bounded KVA active-range 快照。
 2. 申请 1 个 PMM 物理页，并通过 `KeTempPhysMapAcquire()` 建立 fixmap alias。
-3. 检查 fixmap 激活后，物理统计和 VMM 统计是否同步变化。
+3. 检查 fixmap 激活后，物理统计、VMM 统计和 active-range 快照是否同步变化。
 4. 释放临时映射与物理页。
 5. 再做一次 `KeHeapAllocPages()`。
-6. 检查 heap 分配是否推动 PMM/VMM 计数变化。
-7. 最后回收资源并确认所有统计回归基线。
+6. 检查 heap 分配是否推动 PMM/VMM 计数变化，并在 bounded range view 中出现对应 heap range。
+7. `KeClockEventInit()` 之后检查 `KE_SYSINFO_CLOCK_EVENT` 是否暴露 source/vector/frequency 与 `MinDeltaNs/MaxDeltaNs`。
+8. `KeSchedulerInit()` 之后检查 `KE_SYSINFO_SCHEDULER` 是否反映 idle 基线（无 ready/sleep backlog、无 pending deadline）。
+9. 最后回收资源并确认所有统计回归基线。
 
 这让本分支第一次具备了“账本能否闭环”的自动验证。
 
@@ -333,7 +337,7 @@ heap 目前还不是 malloc/slab，而是页级接口：
 - fixmap page fault
 - heap page fault
 
-同时，CPU exception 输出现在遵循“两阶段”契约：始终先输出寄存器转储、`CR2` 与 `PFERR` 位信息；当 vector 14 已切换到 dedicated `IST2` page-fault diagnostic stack 后，再追加 `VMM imported / VMM pt / VMM kva` 三层 richer diagnosis，用于区分 imported 地址、guard page、active fixmap、active heap 或未映射 hole。它们主要用于 bring-up 和 VMM 诊断演练。
+同时，CPU exception 输出现在遵循“两阶段”契约：始终先输出寄存器转储、`CR2` 与 `PFERR` 位信息；当 vector 14 已切换到 dedicated `IST2` page-fault diagnostic stack 后，再追加 `VMM imported / VMM pt / VMM kva` 三层 richer diagnosis，用于区分 imported 地址、guard page、active fixmap、active heap 或未映射 hole。若某层尚未可用，则明确打印 `unavailable` 状态而不是猜测成功结果。这些信息既服务 bring-up，也作为 page-fault regression profile 的稳定诊断锚点。
 
 ## 12. 当前实现边界
 

--- a/docs/design/kva.md
+++ b/docs/design/kva.md
@@ -83,6 +83,7 @@
 
 - `Arena`
 - `RecordId`
+- `Generation`
 - `BaseAddress`
 - `UsableBase`
 - `TotalPages`
@@ -107,13 +108,14 @@
 - 页数
 - `PageStates`
 
-`PageStates` 是每个 arena 的页粒度真相源。当前实现中每页只有三种状态：
+`PageStates` 是每个 arena 的页粒度真相源。当前实现中每页有四种状态：
 
 - `FREE`
 - `ALLOC`
 - `GUARD`
+- `RETIRED`
 
-这里的 `GUARD` 并不表示“已映射但带保护属性”，而是表示“该页属于已保留 range 的 guard 区，不允许作为可用页再次分配，且通常保持未映射”。
+这里的 `GUARD` 并不表示“已映射但带保护属性”，而是表示“该页属于已保留 range 的 guard 区，不允许作为可用页再次分配，且通常保持未映射”；`RETIRED` 则表示该 fixmap 槽位因 generation 耗尽而永久退出后续分配，但仍保留在 arena 地址空间里供可观测性统计。
 
 ### Range 记录
 
@@ -123,6 +125,7 @@
 - `OwnsPhysicalBacking`
 - `Arena`
 - `RecordId`
+- `Generation`
 - `BasePageIndex`
 - `TotalPages`
 - `UsablePages`
@@ -144,7 +147,7 @@
 
 1. 清零所有 `gKvaRanges` 和各 arena 的 `PageStates`。
 2. 根据预定义常量建立 `stack` / `fixmap` / `heap` 三个 arena 的运行时描述。
-3. 为每个 range record 预先写入稳定的 `RecordId`。
+3. 为每个 range slot 预先写入稳定的 `RecordId`，并在每次重新发布该 slot 时分配新的 `Generation`。
 4. 调用 `KiKvaValidateArena` 校验每个 arena：
    - 不与 imported boot mappings 重叠。
    - 在初始化时要求整段虚拟区间目前均未被映射。
@@ -173,9 +176,9 @@
 
 1. `FREE` 页被挑选出来。
 2. guard 页被标记为 `GUARD`，usable 页被标记为 `ALLOC`。
-3. range record 进入 `InUse`。
+3. range record 在其余字段写完后，以新的 `Generation` 一次性进入 `InUse`。
 4. 可选地，为 usable 页建立 4KB 映射。
-5. 释放时，解除映射并把页状态恢复为 `FREE`。
+5. 释放时，解除映射并把页状态恢复为可再次分配的终态；普通 range 回到 `FREE`，而 generation 已耗尽的 fixmap 槽位进入 `RETIRED`。
 
 ## 核心 API 契约
 
@@ -200,11 +203,15 @@
 
 ### `KeKvaMapOwnedPages`
 
-针对 `OwnsPhysicalBacking = TRUE` 的 range，由 KVA 自行逐页向 PMM 申请物理页并映射。若中途任何一步失败，它会回滚已经建立的部分映射并释放整个 range。这样调用方不需要自己逐页清理半成品状态。
+针对 `OwnsPhysicalBacking = TRUE` 的 range，由 KVA 自行逐页向 PMM 申请物理页并映射。若中途任何一步失败，它会用原始 `KE_KVA_RANGE` handle 回滚已经建立的部分映射并释放整个 range，从而拒绝 stale handle 误拆后来复用到同一 slot/VA 的新 owner。
 
 ### `KeKvaReleaseRange`
 
-按 `usableBase` 查找 range，并回收其全部 usable 页映射；如果该 range 拥有物理 backing，则同时把物理页归还 PMM。最后，它会把 guard 与 usable 页统一恢复为 `FREE`，并清空内部 record。
+按 `usableBase` 查找 range，并回收其全部 usable 页映射；如果该 range 拥有物理 backing，则同时把物理页归还 PMM。最后，它会把 guard 与 usable 页恢复为对应 arena 的可见终态：普通 range 回到 `FREE`，generation 已耗尽的 fixmap 槽位进入 `RETIRED`，然后清空内部 record。
+
+### `KeKvaReleaseRangeHandle`
+
+按完整 `KE_KVA_RANGE` handle 释放原始 live range。它会验证 `RecordId + Generation` 以及区间布局字段，确保 stale handle 不会命中已经复用的 slot；需要严格 ownership 语义的调用方应优先使用这一入口。
 
 ### `KeKvaQueryRange`
 
@@ -234,11 +241,11 @@
 
 这是 fixmap 的专用包装接口：
 
-- `Acquire` 在 fixmap arena 中申请一个单页虚拟槽位。
+- `Acquire` 在 fixmap arena 中申请一个单页虚拟槽位，并返回带 generation 的 opaque handle。
 - 然后把调用方提供的物理页映射到该槽位。
-- `Release` 依据 slot 撤销映射并回收槽位。
+- `Release` 必须匹配当次 handle，才能撤销映射并回收槽位。
 
-它为上层提供的是“稳定 API + 简单 slot 语义”，而不是暴露底层 range record。
+它为上层提供的是“稳定 API + recycle-safe handle 语义”，而不是暴露底层 range record 或可长期缓存的裸 slot。
 
 ### `KeHeapAllocPages` / `KeHeapFreePages`
 
@@ -266,7 +273,7 @@
 2. 调用 `KeKvaMapOwnedPages`，逐页申请物理页并映射到 usable 区间。
 3. 将 `thread->StackBase` 记录为 `UsableBase`，将 `thread->StackGuardBase` 记录为整个 range 的 `BaseAddress`。
 4. 调度器始终使用 `StackBase + StackSize` 作为栈顶。
-5. 线程终止后，IdleThread reaper 调用 `KeKvaReleaseRange(thread->StackBase)` 完成栈的整体回收。
+5. 线程终止后，IdleThread reaper 调用 `KeKvaReleaseRangeHandle(&thread->StackRange)` 完成栈的整体回收。
 
 这个切换的意义在于：
 
@@ -344,10 +351,11 @@
 1. `KeKvaInit` 会打印每个 arena 的虚拟地址范围和页数。
 2. `KeKvaQueryArenaInfo` 提供总体空闲页和活跃分配数量。
 3. `KeKvaQueryUsageInfo` 暴露 `ActiveRangeCount`、`FixmapTotalSlots` 与 `FixmapActiveSlots`，供 `KE_SYSINFO_VMM_OVERVIEW` 汇总。
-4. `KeDiagnoseVirtualAddress` 会把 imported-region、PT 映射状态与 KVA 归属信息组合成统一诊断结构。
-5. 页故障蓝屏输出遵循 base-first 契约：先输出寄存器转储、`CR2`、`PFERR` 位域；只有在 dedicated `IST2` 安全诊断上下文中，才追加 `VMM imported / VMM pt / VMM kva` 三层诊断，区分 imported 区域、guard page、active fixmap、active heap 或未映射 hole。
-6. 线程创建日志会直接输出线程栈 usable base 与 guard base。
-7. 线程回收路径在释放 KVA 栈失败时直接触发 panic，避免 silent corruption。
+4. `KeKvaQueryActiveRanges` 额外提供一个固定容量、显式 `Truncated` 的活跃 range 快照；实现会在复制快照时串行化 `gKvaRanges` 的发布/回收元数据，并返回 `RecordId + 64-bit Generation` 来标识当前这一次 live 实例，让平台代码可以用稳定的 arena 和虚拟区间语义观察当前 stack / fixmap / heap-backed range，而不需要直接碰 allocator 内部表。
+5. `KeDiagnoseVirtualAddress` 会把 imported-region、PT 映射状态与 KVA 归属信息组合成统一诊断结构。
+6. 页故障蓝屏输出遵循 base-first 契约：先输出寄存器转储、`CR2`、`PFERR` 位域；只有在 dedicated `IST2` 安全诊断上下文中，才追加 `VMM imported / VMM pt / VMM kva` 三层诊断。若某层当前不可用，会显式报告 `unavailable`，而不是伪造成功分类。
+7. 线程创建日志会直接输出线程栈 usable base 与 guard base。
+8. 线程回收路径在释放 KVA 栈失败时直接触发 panic，避免 silent corruption。
 
 这说明 `KE_KVA` 当前被视为内核关键基础设施，而不是“尽力而为”的辅助模块。
 

--- a/makefile
+++ b/makefile
@@ -38,6 +38,7 @@ HO_DEBUG_BUILD ?= 1
 HO_ENABLE_TIMESTAMP_LOG ?= $(HO_DEBUG_BUILD)
 SUDO ?= sudo
 QEMU_CPU_FLAGS ?= host,+invtsc
+QEMU_DISPLAY ?= gtk
 
 ifeq ($(strip $(SUDO_PASSWORD)),)
 SUDO_RUN := $(SUDO)
@@ -304,6 +305,7 @@ run: copy
 		-m 512M \
 		-bios "$(OVMF_CODE)" \
 		-net none \
+		-display $(QEMU_DISPLAY) \
 		-cpu $(QEMU_CPU_FLAGS) \
 		-enable-kvm \
 		-drive file=fat:rw:esp,index=0,format=vvfat \
@@ -323,6 +325,11 @@ ifeq ($(TEST_MODULE),list)
 	@echo "  pf_guard    - page-fault demo: access thread stack guard page"
 	@echo "  pf_fixmap   - page-fault demo: NX execute fault in active fixmap slot"
 	@echo "  pf_heap     - page-fault demo: NX execute fault in heap-backed KVA page"
+	@echo "Recommended explicit workflow:"
+	@echo "  make clean"
+	@echo "  bear -- make all BUILD_FLAVOR=test-schedule HO_DEMO_TEST_NAME=schedule HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_SCHEDULE"
+	@echo "  BUILD_FLAVOR=test-schedule HO_DEMO_TEST_NAME=schedule HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_SCHEDULE \\"
+	@echo "      bash scripts/qemu_capture.sh 30 /tmp/himuos-schedule.log"
 	@echo "Usage:"
 	@echo "  make test schedule   # run the scheduler demo suite"
 	@echo "  make test irql_wait  # run a dispatch-guard misuse panic regression"
@@ -347,6 +354,7 @@ debug: copy
 		-m 512M \
 		-bios "$(OVMF_CODE)" \
 		-net none \
+		-display $(QEMU_DISPLAY) \
 		-cpu $(QEMU_CPU_FLAGS) \
 		-drive file=fat:rw:esp,index=0,format=vvfat \
 		-serial stdio \

--- a/makefile
+++ b/makefile
@@ -83,7 +83,7 @@ KRN_BUILDROOT := build/kernel$(if $(strip $(BUILD_FLAVOR)),/$(BUILD_FLAVOR),)
 KRN_OBJDIR    := $(KRN_BUILDROOT)/obj
 KRN_BINDIR    := $(KRN_BUILDROOT)/bin
 
-VALID_TEST_MODULES := schedule guard_wait owned_exit irql_wait irql_sleep irql_yield irql_exit pf_imported pf_guard pf_fixmap pf_heap list
+VALID_TEST_MODULES := schedule guard_wait owned_exit irql_wait irql_sleep irql_yield irql_exit pf_imported pf_guard pf_fixmap pf_heap kthread_pool_race list
 TEST_MODULE_GOALS  := $(filter-out test,$(MAKECMDGOALS))
 TEST_MODULE        := $(if $(strip $(TEST_MODULE_GOALS)),$(firstword $(TEST_MODULE_GOALS)),list)
 TEST_BUILD_FLAVOR  := test-$(TEST_MODULE)
@@ -99,14 +99,15 @@ TEST_DEFINE_pf_imported := HO_DEMO_TEST_PF_IMPORTED
 TEST_DEFINE_pf_guard := HO_DEMO_TEST_PF_GUARD
 TEST_DEFINE_pf_fixmap := HO_DEMO_TEST_PF_FIXMAP
 TEST_DEFINE_pf_heap := HO_DEMO_TEST_PF_HEAP
+TEST_DEFINE_kthread_pool_race := HO_DEMO_TEST_KTHREAD_POOL_RACE
 
 ifneq ($(filter test,$(MAKECMDGOALS)),)
 ifneq ($(words $(TEST_MODULE_GOALS)),0)
 ifneq ($(words $(TEST_MODULE_GOALS)),1)
-$(error Usage: make test <module>. Available modules: schedule, guard_wait, owned_exit, irql_wait, irql_sleep, irql_yield, irql_exit, pf_imported, pf_guard, pf_fixmap, pf_heap. Use `make test` or `make test list` to inspect supported modules)
+$(error Usage: make test <module>. Available modules: schedule, guard_wait, owned_exit, irql_wait, irql_sleep, irql_yield, irql_exit, pf_imported, pf_guard, pf_fixmap, pf_heap, kthread_pool_race. Use `make test` or `make test list` to inspect supported modules)
 endif
 ifneq ($(filter $(TEST_MODULE),$(VALID_TEST_MODULES)), $(TEST_MODULE))
-$(error Unknown test module '$(TEST_MODULE)'. Available modules: schedule, guard_wait, owned_exit, irql_wait, irql_sleep, irql_yield, irql_exit, pf_imported, pf_guard, pf_fixmap, pf_heap. Use `make test list` to inspect supported modules)
+$(error Unknown test module '$(TEST_MODULE)'. Available modules: schedule, guard_wait, owned_exit, irql_wait, irql_sleep, irql_yield, irql_exit, pf_imported, pf_guard, pf_fixmap, pf_heap, kthread_pool_race. Use `make test list` to inspect supported modules)
 endif
 endif
 endif
@@ -182,6 +183,7 @@ SRCS_KERNEL_C := \
     src/kernel/demo/irql.c                              \
     src/kernel/demo/mutex.c                             \
     src/kernel/demo/pagefault.c                         \
+	src/kernel/demo/kthread_pool_race.c                 \
     src/kernel/demo/semaphore.c                         \
     src/kernel/demo/thread.c                            \
     src/kernel/init/cpu.c                               \
@@ -325,6 +327,7 @@ ifeq ($(TEST_MODULE),list)
 	@echo "  pf_guard    - page-fault demo: access thread stack guard page"
 	@echo "  pf_fixmap   - page-fault demo: NX execute fault in active fixmap slot"
 	@echo "  pf_heap     - page-fault demo: NX execute fault in heap-backed KVA page"
+	@echo "  kthread_pool_race - regression suite for KTHREAD pool synchronization"
 	@echo "Recommended explicit workflow:"
 	@echo "  make clean"
 	@echo "  bear -- make all BUILD_FLAVOR=test-schedule HO_DEMO_TEST_NAME=schedule HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_SCHEDULE"
@@ -334,6 +337,7 @@ ifeq ($(TEST_MODULE),list)
 	@echo "  make test schedule   # run the scheduler demo suite"
 	@echo "  make test irql_wait  # run a dispatch-guard misuse panic regression"
 	@echo "  make test pf_heap    # run heap-backed page-fault observability demo"
+	@echo "  make test kthread_pool_race # run the KTHREAD pool race regression suite"
 	@echo "  make test            # list available test modules"
 else
 	@echo "Starting test module: $(TEST_MODULE)"

--- a/scripts/qemu_capture.sh
+++ b/scripts/qemu_capture.sh
@@ -7,6 +7,10 @@ set -u
 TIMEOUT=${1:-30}
 OUTPUT_FILE=${2:-/tmp/qemu_output.log}
 SUDO_PASS=${SUDO_PASS:-liuhuan123}
+BUILD_FLAVOR=${BUILD_FLAVOR:-}
+HO_DEMO_TEST_NAME=${HO_DEMO_TEST_NAME:-}
+HO_DEMO_TEST_DEFINE=${HO_DEMO_TEST_DEFINE:-}
+QEMU_DISPLAY=${QEMU_DISPLAY:-none}
 TMP_DIR=$(mktemp -d /tmp/qemu_capture.XXXXXX)
 FIFO_PATH="${TMP_DIR}/output.fifo"
 RUNNER_PID=""
@@ -33,6 +37,13 @@ trap 'kill_runner_group TERM; sleep 1; kill_runner_group KILL; exit 130' INT TER
 
 echo "Starting QEMU with ${TIMEOUT}s timeout..."
 echo "Output will be saved to: ${OUTPUT_FILE}"
+if [ -n "$BUILD_FLAVOR" ]; then
+	echo "Using BUILD_FLAVOR=${BUILD_FLAVOR}"
+fi
+if [ -n "$HO_DEMO_TEST_NAME" ] && [ -n "$HO_DEMO_TEST_DEFINE" ]; then
+	echo "Using demo profile ${HO_DEMO_TEST_NAME} (${HO_DEMO_TEST_DEFINE})"
+fi
+echo "Using QEMU_DISPLAY=${QEMU_DISPLAY}"
 
 mkfifo "$FIFO_PATH"
 tee "$OUTPUT_FILE" <"$FIFO_PATH" &
@@ -40,7 +51,8 @@ TEE_PID=$!
 
 # Start make/qemu in its own process group so timeout handling can terminate
 # the whole tree instead of only the shell or tee process.
-setsid bash -lc 'exec make run SUDO_PASSWORD="$1"' _ "$SUDO_PASS" >"$FIFO_PATH" 2>&1 &
+setsid bash -lc 'exec make run SUDO_PASSWORD="$1" BUILD_FLAVOR="$2" HO_DEMO_TEST_NAME="$3" HO_DEMO_TEST_DEFINE="$4" QEMU_DISPLAY="$5"' \
+	_ "$SUDO_PASS" "$BUILD_FLAVOR" "$HO_DEMO_TEST_NAME" "$HO_DEMO_TEST_DEFINE" "$QEMU_DISPLAY" >"$FIFO_PATH" 2>&1 &
 RUNNER_PID=$!
 RUNNER_PGID=$(ps -o pgid= -p "$RUNNER_PID" | tr -d '[:space:]')
 

--- a/src/include/kernel/ke/kthread.h
+++ b/src/include/kernel/ke/kthread.h
@@ -11,6 +11,7 @@
 
 #include <_hobase.h>
 #include <lib/common/linked_list.h>
+#include <kernel/ke/mm.h>
 #include <kernel/ke/pool.h>
 #include <kernel/ke/irql.h>
 #include <kernel/ke/dispatcher.h>
@@ -66,6 +67,7 @@ typedef struct KTHREAD
     uint64_t StackSize;      // Usable stack size in bytes
     uint64_t StackGuardBase; // Lowest guard-page virtual address (0 if not KVA-managed)
     BOOL StackOwnedByKva;
+    KE_KVA_RANGE StackRange;
 
     uint8_t Priority; // Reserved for multi-priority extension
     uint64_t Quantum; // Time slice remaining (nanoseconds)

--- a/src/include/kernel/ke/mm.h
+++ b/src/include/kernel/ke/mm.h
@@ -76,6 +76,7 @@ typedef struct KE_KVA_RANGE
 {
     KE_KVA_ARENA_TYPE Arena;
     uint32_t RecordId;
+    uint64_t Generation;
     HO_VIRTUAL_ADDRESS BaseAddress;
     HO_VIRTUAL_ADDRESS UsableBase;
     uint64_t TotalPages;
@@ -102,9 +103,34 @@ typedef struct KE_KVA_USAGE_INFO
     uint64_t FixmapActiveSlots;
 } KE_KVA_USAGE_INFO;
 
+#define KE_KVA_ACTIVE_RANGE_SNAPSHOT_MAX 16U
+
+typedef struct KE_KVA_ACTIVE_RANGE_ENTRY
+{
+    KE_KVA_ARENA_TYPE Arena;
+    uint32_t RecordId;
+    uint64_t Generation;
+    HO_VIRTUAL_ADDRESS BaseAddress;
+    HO_VIRTUAL_ADDRESS EndAddressExclusive;
+    HO_VIRTUAL_ADDRESS UsableBase;
+    HO_VIRTUAL_ADDRESS UsableEndExclusive;
+    uint64_t TotalPages;
+    uint64_t UsablePages;
+    uint64_t GuardLowerPages;
+    uint64_t GuardUpperPages;
+} KE_KVA_ACTIVE_RANGE_ENTRY;
+
+typedef struct KE_KVA_ACTIVE_RANGE_SNAPSHOT
+{
+    uint64_t TotalActiveRangeCount;
+    uint32_t ReturnedRangeCount;
+    BOOL Truncated;
+    KE_KVA_ACTIVE_RANGE_ENTRY Ranges[KE_KVA_ACTIVE_RANGE_SNAPSHOT_MAX];
+} KE_KVA_ACTIVE_RANGE_SNAPSHOT;
+
 typedef struct KE_TEMP_PHYS_MAP_HANDLE
 {
-    uint32_t Token;
+    uint64_t Token;
 } KE_TEMP_PHYS_MAP_HANDLE;
 
 typedef enum KE_KVA_ADDRESS_KIND
@@ -268,6 +294,21 @@ HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaMapPage(const KE_KVA_RANGE *range,
  */
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaMapOwnedPages(const KE_KVA_RANGE *range, uint64_t attributes);
 
+/**
+ * Release the exact live range described by a previously returned handle.
+ *
+ * This validates the slot, generation, and layout fields before teardown so a
+ * stale `KE_KVA_RANGE` cannot release a recycled allocation.
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaReleaseRangeHandle(const KE_KVA_RANGE *range);
+
+/**
+ * Release the current range that owns @usableBase.
+ *
+ * This is an address-based convenience API. Callers that need recycle-safe
+ * ownership semantics should retain the original `KE_KVA_RANGE` handle and use
+ * `KeKvaReleaseRangeHandle()`.
+ */
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaReleaseRange(HO_VIRTUAL_ADDRESS usableBase);
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaQueryRange(HO_VIRTUAL_ADDRESS usableBase, KE_KVA_RANGE *outRange);
@@ -275,6 +316,15 @@ HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaQueryRange(HO_VIRTUAL_ADDRESS usableBa
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaQueryArenaInfo(KE_KVA_ARENA_TYPE arena, KE_KVA_ARENA_INFO *outInfo);
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaQueryUsageInfo(KE_KVA_USAGE_INFO *outInfo);
+
+/**
+ * Copy a bounded, internally consistent snapshot of active KVA ranges.
+ *
+ * The allocator serializes range-table publication and recycle while this
+ * snapshot is assembled, so returned entries never expose partially
+ * initialized or already-recycled records.
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaQueryActiveRanges(KE_KVA_ACTIVE_RANGE_SNAPSHOT *outSnapshot);
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaClassifyAddress(HO_VIRTUAL_ADDRESS virtAddr, KE_KVA_ADDRESS_INFO *outInfo);
 
@@ -284,10 +334,10 @@ HO_KERNEL_API HO_NODISCARD HO_STATUS KeKvaSelfTest(void);
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeFixmapAcquire(HO_PHYSICAL_ADDRESS physAddr,
                                                      uint64_t attributes,
-                                                     uint32_t *outSlot,
+                                                     KE_TEMP_PHYS_MAP_HANDLE *outHandle,
                                                      HO_VIRTUAL_ADDRESS *outVirtAddr);
 
-HO_KERNEL_API HO_NODISCARD HO_STATUS KeFixmapRelease(uint32_t slot);
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeFixmapRelease(KE_TEMP_PHYS_MAP_HANDLE *handle);
 
 /**
  * Acquire a short-lived runtime alias for one physical page through fixmap.

--- a/src/include/kernel/ke/sysinfo.h
+++ b/src/include/kernel/ke/sysinfo.h
@@ -12,6 +12,7 @@
 #include <_hobase.h>
 #include <arch/amd64/pm.h>
 #include <arch/arch.h>
+#include <kernel/ke/mm.h>
 
 // ─────────────────────────────────────────────────────────────
 // Information Class Enumeration
@@ -34,6 +35,7 @@ typedef enum KE_SYSINFO_CLASS
     KE_SYSINFO_CLOCK_EVENT = 12,
     KE_SYSINFO_SCHEDULER = 13,
     KE_SYSINFO_VMM_OVERVIEW = 14,
+    KE_SYSINFO_ACTIVE_KVA_RANGES = 15,
     KE_SYSINFO_MAX
 } KE_SYSINFO_CLASS;
 
@@ -95,6 +97,31 @@ typedef struct SYSINFO_VMM_OVERVIEW
     uint64_t FixmapActiveSlots;
 } SYSINFO_VMM_OVERVIEW;
 
+#define SYSINFO_ACTIVE_KVA_RANGE_MAX 16U
+
+typedef struct SYSINFO_ACTIVE_KVA_RANGE
+{
+    KE_KVA_ARENA_TYPE Arena;
+    uint32_t RecordId;
+    uint64_t Generation;
+    HO_VIRTUAL_ADDRESS BaseAddress;
+    HO_VIRTUAL_ADDRESS EndAddressExclusive;
+    HO_VIRTUAL_ADDRESS UsableBase;
+    HO_VIRTUAL_ADDRESS UsableEndExclusive;
+    uint64_t TotalPages;
+    uint64_t UsablePages;
+    uint64_t GuardLowerPages;
+    uint64_t GuardUpperPages;
+} SYSINFO_ACTIVE_KVA_RANGE;
+
+typedef struct SYSINFO_ACTIVE_KVA_RANGES
+{
+    uint64_t TotalActiveRangeCount;
+    uint32_t ReturnedRangeCount;
+    BOOL Truncated;
+    SYSINFO_ACTIVE_KVA_RANGE Ranges[SYSINFO_ACTIVE_KVA_RANGE_MAX];
+} SYSINFO_ACTIVE_KVA_RANGES;
+
 // KE_SYSINFO_GDT
 typedef struct SYSINFO_GDT
 {
@@ -143,6 +170,8 @@ typedef struct SYSINFO_CLOCK_EVENT
     BOOL Ready;
     uint64_t FreqHz;
     uint64_t InterruptCount;
+    uint64_t MinDeltaNs;
+    uint64_t MaxDeltaNs;
     uint8_t VectorNumber;
     char SourceName[SYSINFO_TIME_SOURCE_NAME_LEN];
 } SYSINFO_CLOCK_EVENT;

--- a/src/kernel/demo/demo.c
+++ b/src/kernel/demo/demo.c
@@ -101,6 +101,11 @@ RunKernelDemos(void)
     {
         RunPageFaultHeapDemo();
     }
+
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_KTHREAD_POOL_RACE)
+    {
+        RunKthreadPoolRaceDemo();
+    }
 }
 
 void

--- a/src/kernel/demo/demo_internal.h
+++ b/src/kernel/demo/demo_internal.h
@@ -35,6 +35,7 @@
 #define HO_DEMO_TEST_PF_GUARD    13
 #define HO_DEMO_TEST_PF_FIXMAP   14
 #define HO_DEMO_TEST_PF_HEAP     15
+#define HO_DEMO_TEST_KTHREAD_POOL_RACE 16
 
 #ifndef HO_DEMO_TEST_SELECTION
 #define HO_DEMO_TEST_SELECTION HO_DEMO_TEST_NONE
@@ -95,3 +96,4 @@ void RunPageFaultImportedDemo(void);
 void RunPageFaultGuardDemo(void);
 void RunPageFaultFixmapDemo(void);
 void RunPageFaultHeapDemo(void);
+void RunKthreadPoolRaceDemo(void);

--- a/src/kernel/demo/kthread_pool_race.c
+++ b/src/kernel/demo/kthread_pool_race.c
@@ -1,0 +1,401 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: demo/kthread_pool_race.c
+ * Description: Regression suite for KTHREAD pool synchronization and lifecycle safety.
+ *
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#include "demo_internal.h"
+#include <libc/string.h>
+
+#define POOL_RACE_WORKER_COUNT              2U
+#define POOL_RACE_ALLOCATIONS_PER_WORKER    24U
+#define CREATE_RACE_CREATOR_COUNT           2U
+#define CREATE_RACE_CHILDREN_PER_CREATOR    6U
+#define CREATE_RACE_TOTAL_CHILDREN          (CREATE_RACE_CREATOR_COUNT * CREATE_RACE_CHILDREN_PER_CREATOR)
+#define REAP_RACE_CHILD_COUNT               10U
+#define POOL_SETTLE_EXPECTED_USED_SLOTS     2U
+#define POOL_SETTLE_MAX_RETRIES             64U
+#define POOL_SETTLE_SLEEP_NS                1000000ULL
+
+typedef struct KI_POOL_RACE_WORKER_CONTEXT
+{
+    KE_POOL *Pool;
+    KEVENT *StartEvent;
+    KSEMAPHORE *DoneSemaphore;
+    uint32_t AllocationCount;
+    uint8_t FillPattern;
+} KI_POOL_RACE_WORKER_CONTEXT;
+
+typedef struct KI_CREATE_RACE_CREATOR_CONTEXT
+{
+    KEVENT *StartEvent;
+    KSEMAPHORE *DoneSemaphore;
+    KSEMAPHORE *ChildExitSemaphore;
+    uint32_t *RecordedIds;
+    uint32_t Count;
+    BOOL SleepBetweenCreates;
+} KI_CREATE_RACE_CREATOR_CONTEXT;
+
+static KE_POOL gPoolRaceRegressionPool;
+static KEVENT gPoolRaceStartEvent;
+static KSEMAPHORE gPoolRaceDoneSemaphore;
+static KI_POOL_RACE_WORKER_CONTEXT gPoolRaceWorkerContexts[POOL_RACE_WORKER_COUNT];
+
+static KEVENT gCreateRaceStartEvent;
+static KSEMAPHORE gCreateRaceDoneSemaphore;
+static KSEMAPHORE gCreateRaceChildExitSemaphore;
+static uint32_t gCreateRaceRecordedIds[CREATE_RACE_TOTAL_CHILDREN];
+static KI_CREATE_RACE_CREATOR_CONTEXT gCreateRaceContexts[CREATE_RACE_CREATOR_COUNT];
+
+static KEVENT gReapRaceStartEvent;
+static KSEMAPHORE gReapRaceDoneSemaphore;
+static KSEMAPHORE gReapRaceChildExitSemaphore;
+static uint32_t gReapRaceRecordedIds[REAP_RACE_CHILD_COUNT];
+static KI_CREATE_RACE_CREATOR_CONTEXT gReapRaceContext;
+
+static void KiWaitForSemaphorePermits(KSEMAPHORE *semaphore, uint32_t count, const char *reason);
+static void KiReadPoolAccounting(KE_POOL *pool, uint32_t *usedSlots, uint32_t *totalSlots);
+static uint32_t KiCountPoolFreeNodes(KE_POOL *pool);
+static void KiWaitForPoolToSettle(KE_POOL *pool, uint32_t expectedUsedSlots, const char *reason);
+static void KiVerifyDistinctThreadIds(const uint32_t *ids, uint32_t count, const char *reason);
+static void KiRunPoolInterleavingRegression(void);
+static void KiRunThreadIdRegression(void);
+static void KiRunCreateReapRegression(void);
+static void KthreadPoolRaceControllerThread(void *arg);
+static void PoolRaceWorkerThread(void *arg);
+static void KthreadPoolRecordedWorkerThread(void *arg);
+static void ThreadIdCreatorThread(void *arg);
+void KiReapTerminatedThreads(void);
+
+void
+RunKthreadPoolRaceDemo(void)
+{
+    KTHREAD *controller = NULL;
+    HO_STATUS status = KeThreadCreate(&controller, KthreadPoolRaceControllerThread, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create KTHREAD pool regression controller");
+
+    status = KeThreadStart(controller);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start KTHREAD pool regression controller");
+}
+
+static void
+KiWaitForSemaphorePermits(KSEMAPHORE *semaphore, uint32_t count, const char *reason)
+{
+    for (uint32_t i = 0; i < count; i++)
+    {
+        HO_STATUS status = KeWaitForSingleObject(semaphore, KE_WAIT_INFINITE);
+        if (status != EC_SUCCESS)
+        {
+            klog(KLOG_LEVEL_ERROR, "[TEST] %s wait failed at permit %u/%u\n", reason, i + 1, count);
+            HO_KPANIC(status, "KTHREAD pool regression wait failed");
+        }
+    }
+}
+
+static void
+KiReadPoolAccounting(KE_POOL *pool, uint32_t *usedSlots, uint32_t *totalSlots)
+{
+    KE_CRITICAL_SECTION criticalSection = {0};
+
+    KeEnterCriticalSection(&criticalSection);
+    if (usedSlots != NULL)
+        *usedSlots = pool->UsedSlots;
+    if (totalSlots != NULL)
+        *totalSlots = pool->TotalSlots;
+    KeLeaveCriticalSection(&criticalSection);
+}
+
+static uint32_t
+KiCountPoolFreeNodes(KE_POOL *pool)
+{
+    KE_CRITICAL_SECTION criticalSection = {0};
+    uint32_t freeCount = 0;
+
+    KeEnterCriticalSection(&criticalSection);
+
+    for (KE_POOL_FREE_NODE *node = pool->FreeList; node != NULL; node = node->Next)
+    {
+        freeCount++;
+        HO_KASSERT(freeCount <= pool->TotalSlots, EC_INVALID_STATE);
+    }
+
+    HO_KASSERT(freeCount + pool->UsedSlots == pool->TotalSlots, EC_INVALID_STATE);
+    KeLeaveCriticalSection(&criticalSection);
+    return freeCount;
+}
+
+static void
+KiWaitForPoolToSettle(KE_POOL *pool, uint32_t expectedUsedSlots, const char *reason)
+{
+    uint32_t usedSlots = 0;
+    uint32_t totalSlots = 0;
+
+    for (uint32_t attempt = 0; attempt < POOL_SETTLE_MAX_RETRIES; attempt++)
+    {
+        KiReapTerminatedThreads();
+
+        KiReadPoolAccounting(pool, &usedSlots, &totalSlots);
+        if (usedSlots == expectedUsedSlots)
+            return;
+
+        KeSleep(POOL_SETTLE_SLEEP_NS);
+    }
+
+    klog(KLOG_LEVEL_ERROR, "[TEST] pool did not settle for %s (used=%u total=%u expected=%u)\n", reason, usedSlots,
+         totalSlots, expectedUsedSlots);
+    HO_KPANIC(EC_TIMEOUT, "KTHREAD pool regression settle timeout");
+}
+
+static void
+KiVerifyDistinctThreadIds(const uint32_t *ids, uint32_t count, const char *reason)
+{
+    for (uint32_t i = 0; i < count; i++)
+    {
+        HO_KASSERT(ids[i] != 0, EC_INVALID_STATE);
+        for (uint32_t j = i + 1; j < count; j++)
+        {
+            HO_KASSERT(ids[i] != ids[j], EC_INVALID_STATE);
+        }
+    }
+
+    klog(KLOG_LEVEL_INFO, "[TEST] %s verified %u distinct ThreadId values\n", reason, count);
+}
+
+static void
+KiRunPoolInterleavingRegression(void)
+{
+    klog(KLOG_LEVEL_INFO, "[TEST] pool interleaving regression start\n");
+
+    HO_STATUS status = KePoolInit(&gPoolRaceRegressionPool, 256, 4, "pool-race-regression");
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to initialize shared regression pool");
+
+    KeInitializeEvent(&gPoolRaceStartEvent, FALSE);
+    status = KeInitializeSemaphore(&gPoolRaceDoneSemaphore, 0, POOL_RACE_WORKER_COUNT);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to initialize pool regression semaphore");
+
+    for (uint32_t i = 0; i < POOL_RACE_WORKER_COUNT; i++)
+    {
+        gPoolRaceWorkerContexts[i].Pool = &gPoolRaceRegressionPool;
+        gPoolRaceWorkerContexts[i].StartEvent = &gPoolRaceStartEvent;
+        gPoolRaceWorkerContexts[i].DoneSemaphore = &gPoolRaceDoneSemaphore;
+        gPoolRaceWorkerContexts[i].AllocationCount = POOL_RACE_ALLOCATIONS_PER_WORKER;
+        gPoolRaceWorkerContexts[i].FillPattern = (uint8_t)(0xA0U + i);
+
+        KTHREAD *worker = NULL;
+        status = KeThreadCreate(&worker, PoolRaceWorkerThread, &gPoolRaceWorkerContexts[i]);
+        if (status != EC_SUCCESS)
+            HO_KPANIC(status, "Failed to create pool regression worker");
+
+        status = KeThreadStart(worker);
+        if (status != EC_SUCCESS)
+            HO_KPANIC(status, "Failed to start pool regression worker");
+    }
+
+    KeSetEvent(&gPoolRaceStartEvent);
+    KiWaitForSemaphorePermits(&gPoolRaceDoneSemaphore, POOL_RACE_WORKER_COUNT, "pool regression workers");
+    KiWaitForPoolToSettle(&gKThreadPool, POOL_SETTLE_EXPECTED_USED_SLOTS, "pool regression worker reap");
+
+    uint32_t usedSlots;
+    uint32_t totalSlots;
+    uint32_t freeCount = KiCountPoolFreeNodes(&gPoolRaceRegressionPool);
+    KiReadPoolAccounting(&gPoolRaceRegressionPool, &usedSlots, &totalSlots);
+
+    HO_KASSERT(usedSlots == 0, EC_INVALID_STATE);
+    HO_KASSERT(freeCount == totalSlots, EC_INVALID_STATE);
+    HO_KASSERT(totalSlots >= POOL_RACE_WORKER_COUNT * POOL_RACE_ALLOCATIONS_PER_WORKER, EC_INVALID_STATE);
+
+    klog(KLOG_LEVEL_INFO, "[TEST] pool interleaving regression passed (slots=%u)\n", totalSlots);
+}
+
+static void
+KiRunThreadIdRegression(void)
+{
+    klog(KLOG_LEVEL_INFO, "[TEST] create/create ThreadId regression start\n");
+
+    memset(gCreateRaceRecordedIds, 0, sizeof(gCreateRaceRecordedIds));
+
+    KeInitializeEvent(&gCreateRaceStartEvent, FALSE);
+
+    HO_STATUS status = KeInitializeSemaphore(&gCreateRaceDoneSemaphore, 0, CREATE_RACE_CREATOR_COUNT);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to initialize creator completion semaphore");
+
+    status = KeInitializeSemaphore(&gCreateRaceChildExitSemaphore, 0, CREATE_RACE_TOTAL_CHILDREN);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to initialize child exit semaphore");
+
+    for (uint32_t i = 0; i < CREATE_RACE_CREATOR_COUNT; i++)
+    {
+        gCreateRaceContexts[i].StartEvent = &gCreateRaceStartEvent;
+        gCreateRaceContexts[i].DoneSemaphore = &gCreateRaceDoneSemaphore;
+        gCreateRaceContexts[i].ChildExitSemaphore = &gCreateRaceChildExitSemaphore;
+        gCreateRaceContexts[i].RecordedIds = &gCreateRaceRecordedIds[i * CREATE_RACE_CHILDREN_PER_CREATOR];
+        gCreateRaceContexts[i].Count = CREATE_RACE_CHILDREN_PER_CREATOR;
+        gCreateRaceContexts[i].SleepBetweenCreates = FALSE;
+
+        KTHREAD *creator = NULL;
+        status = KeThreadCreate(&creator, ThreadIdCreatorThread, &gCreateRaceContexts[i]);
+        if (status != EC_SUCCESS)
+            HO_KPANIC(status, "Failed to create ThreadId regression creator");
+
+        status = KeThreadStart(creator);
+        if (status != EC_SUCCESS)
+            HO_KPANIC(status, "Failed to start ThreadId regression creator");
+    }
+
+    KeSetEvent(&gCreateRaceStartEvent);
+    KiWaitForSemaphorePermits(&gCreateRaceDoneSemaphore, CREATE_RACE_CREATOR_COUNT, "ThreadId creators");
+    KiVerifyDistinctThreadIds(gCreateRaceRecordedIds, CREATE_RACE_TOTAL_CHILDREN, "create/create regression");
+    KiWaitForSemaphorePermits(&gCreateRaceChildExitSemaphore, CREATE_RACE_TOTAL_CHILDREN,
+                              "create/create child exits");
+    KiWaitForPoolToSettle(&gKThreadPool, POOL_SETTLE_EXPECTED_USED_SLOTS, "create/create reap");
+
+    klog(KLOG_LEVEL_INFO, "[TEST] create/create ThreadId regression passed\n");
+}
+
+static void
+KiRunCreateReapRegression(void)
+{
+    klog(KLOG_LEVEL_INFO, "[TEST] create/reap regression start\n");
+
+    memset(gReapRaceRecordedIds, 0, sizeof(gReapRaceRecordedIds));
+    KeInitializeEvent(&gReapRaceStartEvent, FALSE);
+
+    HO_STATUS status = KeInitializeSemaphore(&gReapRaceDoneSemaphore, 0, 1);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to initialize create/reap completion semaphore");
+
+    status = KeInitializeSemaphore(&gReapRaceChildExitSemaphore, 0, REAP_RACE_CHILD_COUNT);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to initialize create/reap child exit semaphore");
+
+    gReapRaceContext.StartEvent = &gReapRaceStartEvent;
+    gReapRaceContext.DoneSemaphore = &gReapRaceDoneSemaphore;
+    gReapRaceContext.ChildExitSemaphore = &gReapRaceChildExitSemaphore;
+    gReapRaceContext.RecordedIds = gReapRaceRecordedIds;
+    gReapRaceContext.Count = REAP_RACE_CHILD_COUNT;
+    gReapRaceContext.SleepBetweenCreates = TRUE;
+
+    KTHREAD *creator = NULL;
+    status = KeThreadCreate(&creator, ThreadIdCreatorThread, &gReapRaceContext);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create create/reap regression creator");
+
+    status = KeThreadStart(creator);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start create/reap regression creator");
+
+    KeSetEvent(&gReapRaceStartEvent);
+    KiWaitForSemaphorePermits(&gReapRaceDoneSemaphore, 1, "create/reap creator");
+    KiWaitForSemaphorePermits(&gReapRaceChildExitSemaphore, REAP_RACE_CHILD_COUNT, "create/reap child exits");
+    KiWaitForPoolToSettle(&gKThreadPool, POOL_SETTLE_EXPECTED_USED_SLOTS, "create/reap reap");
+
+    uint32_t usedSlots;
+    uint32_t totalSlots;
+    uint32_t freeCount = KiCountPoolFreeNodes(&gKThreadPool);
+    KiReadPoolAccounting(&gKThreadPool, &usedSlots, &totalSlots);
+
+    HO_KASSERT(usedSlots == POOL_SETTLE_EXPECTED_USED_SLOTS, EC_INVALID_STATE);
+    HO_KASSERT(freeCount + usedSlots == totalSlots, EC_INVALID_STATE);
+
+    klog(KLOG_LEVEL_INFO, "[TEST] create/reap regression passed (used=%u total=%u free=%u)\n", usedSlots,
+         totalSlots, freeCount);
+}
+
+static void
+KthreadPoolRaceControllerThread(void *arg)
+{
+    (void)arg;
+
+    klog(KLOG_LEVEL_INFO, "[TEST] KTHREAD pool race regression controller start\n");
+    KiRunPoolInterleavingRegression();
+    KiRunThreadIdRegression();
+    KiRunCreateReapRegression();
+    klog(KLOG_LEVEL_INFO, "[TEST] KTHREAD pool race regression suite passed\n");
+}
+
+static void
+PoolRaceWorkerThread(void *arg)
+{
+    KI_POOL_RACE_WORKER_CONTEXT *context = (KI_POOL_RACE_WORKER_CONTEXT *)arg;
+    void *objects[POOL_RACE_ALLOCATIONS_PER_WORKER] = {0};
+
+    HO_STATUS status = KeWaitForSingleObject(context->StartEvent, KE_WAIT_INFINITE);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Pool regression worker failed waiting for start event");
+
+    HO_KASSERT(context->AllocationCount <= POOL_RACE_ALLOCATIONS_PER_WORKER, EC_ILLEGAL_ARGUMENT);
+
+    for (uint32_t i = 0; i < context->AllocationCount; i++)
+    {
+        objects[i] = KePoolAlloc(context->Pool);
+        HO_KASSERT(objects[i] != NULL, EC_OUT_OF_RESOURCE);
+
+        memset(objects[i], context->FillPattern, context->Pool->SlotSize);
+
+        if ((i & 1U) == 0)
+            KeYield();
+    }
+
+    for (uint32_t i = context->AllocationCount; i > 0; i--)
+    {
+        KePoolFree(context->Pool, objects[i - 1]);
+
+        if ((i & 1U) == 0)
+            KeYield();
+    }
+
+    status = KeReleaseSemaphore(context->DoneSemaphore, 1);
+    HO_KASSERT(status == EC_SUCCESS, status);
+}
+
+static void
+KthreadPoolRecordedWorkerThread(void *arg)
+{
+    KSEMAPHORE *childExitSemaphore = (KSEMAPHORE *)arg;
+
+    KeYield();
+
+    HO_STATUS status = KeReleaseSemaphore(childExitSemaphore, 1);
+    HO_KASSERT(status == EC_SUCCESS, status);
+}
+
+static void
+ThreadIdCreatorThread(void *arg)
+{
+    KI_CREATE_RACE_CREATOR_CONTEXT *context = (KI_CREATE_RACE_CREATOR_CONTEXT *)arg;
+
+    HO_STATUS status = KeWaitForSingleObject(context->StartEvent, KE_WAIT_INFINITE);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Thread creator failed waiting for start event");
+
+    for (uint32_t i = 0; i < context->Count; i++)
+    {
+        KTHREAD *child = NULL;
+
+        status = KeThreadCreate(&child, KthreadPoolRecordedWorkerThread, context->ChildExitSemaphore);
+        if (status != EC_SUCCESS)
+            HO_KPANIC(status, "Thread creator failed to allocate child thread");
+
+        context->RecordedIds[i] = child->ThreadId;
+
+        status = KeThreadStart(child);
+        if (status != EC_SUCCESS)
+            HO_KPANIC(status, "Thread creator failed to start child thread");
+
+        if (context->SleepBetweenCreates)
+            KeSleep(POOL_SETTLE_SLEEP_NS);
+        else
+            KeYield();
+    }
+
+    status = KeReleaseSemaphore(context->DoneSemaphore, 1);
+    HO_KASSERT(status == EC_SUCCESS, status);
+}

--- a/src/kernel/hoentry.c
+++ b/src/kernel/hoentry.c
@@ -15,6 +15,7 @@
 #include <kernel/ke/sysinfo.h>
 #include <kernel/ke/scheduler.h>
 #include <kernel/demo.h>
+#include "demo/demo_internal.h"
 
 static void PrintBootBanner(void);
 
@@ -69,6 +70,7 @@ PrintBootBanner(void)
         kprintf("  %-24s %s %s\n", "Build", ver.BuildDate, ver.BuildTime);
     }
     kprintf("  %-24s %s\n", "------------------------", "------------------------------------------");
+    kprintf("  %-24s %s\n", "Active Profile", HO_DEMO_TEST_SELECTION_NAME);
 
     kprintf("Copyright(c) 2024-2025 Himu, ONLY FOR EDUCATIONAL PURPOSES.\n\n");
 }

--- a/src/kernel/init/init.c
+++ b/src/kernel/init/init.c
@@ -28,6 +28,30 @@ KiQueryVmmOverview(SYSINFO_VMM_OVERVIEW *outOverview)
 }
 
 static HO_STATUS
+KiQuerySchedulerInfo(KE_SYSINFO_SCHEDULER_DATA *outInfo)
+{
+    if (!outInfo)
+        return EC_ILLEGAL_ARGUMENT;
+    return KeQuerySystemInformation(KE_SYSINFO_SCHEDULER, outInfo, sizeof(*outInfo), NULL);
+}
+
+static HO_STATUS
+KiQueryClockEventInfo(SYSINFO_CLOCK_EVENT *outInfo)
+{
+    if (!outInfo)
+        return EC_ILLEGAL_ARGUMENT;
+    return KeQuerySystemInformation(KE_SYSINFO_CLOCK_EVENT, outInfo, sizeof(*outInfo), NULL);
+}
+
+static HO_STATUS
+KiQueryActiveKvaRanges(SYSINFO_ACTIVE_KVA_RANGES *outInfo)
+{
+    if (!outInfo)
+        return EC_ILLEGAL_ARGUMENT;
+    return KeQuerySystemInformation(KE_SYSINFO_ACTIVE_KVA_RANGES, outInfo, sizeof(*outInfo), NULL);
+}
+
+static HO_STATUS
 RunMemoryObservabilitySelfTest(void)
 {
     SYSINFO_PHYSICAL_MEM_STATS basePhysical = {0};
@@ -47,11 +71,18 @@ RunMemoryObservabilitySelfTest(void)
     HO_VIRTUAL_ADDRESS tempVirt = 0;
     HO_VIRTUAL_ADDRESS heapVirt = 0;
     BOOL heapAllocated = FALSE;
+    SYSINFO_ACTIVE_KVA_RANGES baseRanges = {0};
+    SYSINFO_ACTIVE_KVA_RANGES fixmapRanges = {0};
+    SYSINFO_ACTIVE_KVA_RANGES heapRanges = {0};
+    SYSINFO_ACTIVE_KVA_RANGES finalRanges = {0};
 
     HO_STATUS status = KiQueryPhysicalStats(&basePhysical);
     if (status != EC_SUCCESS)
         return status;
     status = KiQueryVmmOverview(&baseVmm);
+    if (status != EC_SUCCESS)
+        return status;
+    status = KiQueryActiveKvaRanges(&baseRanges);
     if (status != EC_SUCCESS)
         return status;
 
@@ -79,6 +110,9 @@ RunMemoryObservabilitySelfTest(void)
     status = KiQueryVmmOverview(&fixmapVmm);
     if (status != EC_SUCCESS)
         goto cleanup;
+    status = KiQueryActiveKvaRanges(&fixmapRanges);
+    if (status != EC_SUCCESS)
+        goto cleanup;
 
     if (fixmapPhysical.AllocatedBytes < basePhysical.AllocatedBytes + PAGE_4KB ||
         fixmapPhysical.FreeBytes + PAGE_4KB > basePhysical.FreeBytes)
@@ -89,6 +123,26 @@ RunMemoryObservabilitySelfTest(void)
     if (fixmapVmm.FixmapActiveSlots != baseVmm.FixmapActiveSlots + 1 ||
         fixmapVmm.FixmapArena.ActiveAllocations != baseVmm.FixmapArena.ActiveAllocations + 1 ||
         fixmapVmm.ActiveKvaRangeCount < baseVmm.ActiveKvaRangeCount + 1)
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+    if (fixmapRanges.TotalActiveRangeCount < baseRanges.TotalActiveRangeCount + 1)
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+
+    BOOL foundFixmapRange = FALSE;
+    for (uint32_t idx = 0; idx < fixmapRanges.ReturnedRangeCount; ++idx)
+    {
+        if (fixmapRanges.Ranges[idx].Arena == KE_KVA_ARENA_FIXMAP && fixmapRanges.Ranges[idx].UsableBase == tempVirt)
+        {
+            foundFixmapRange = TRUE;
+            break;
+        }
+    }
+    if (!foundFixmapRange && !fixmapRanges.Truncated)
     {
         status = EC_INVALID_STATE;
         goto cleanup;
@@ -124,8 +178,12 @@ RunMemoryObservabilitySelfTest(void)
     status = KiQueryVmmOverview(&heapVmm);
     if (status != EC_SUCCESS)
         goto cleanup;
+    status = KiQueryActiveKvaRanges(&heapRanges);
+    if (status != EC_SUCCESS)
+        goto cleanup;
 
-    if (heapPhysical.AllocatedBytes < basePhysical.AllocatedBytes + PAGE_4KB || heapPhysical.FreeBytes > basePhysical.FreeBytes)
+    if (heapPhysical.AllocatedBytes < basePhysical.AllocatedBytes + PAGE_4KB ||
+        heapPhysical.FreeBytes > basePhysical.FreeBytes)
     {
         status = EC_INVALID_STATE;
         goto cleanup;
@@ -133,6 +191,26 @@ RunMemoryObservabilitySelfTest(void)
     if (heapVmm.HeapArena.ActiveAllocations != baseVmm.HeapArena.ActiveAllocations + 1 ||
         heapVmm.ActiveKvaRangeCount < baseVmm.ActiveKvaRangeCount + 1 ||
         heapVmm.FixmapActiveSlots != baseVmm.FixmapActiveSlots)
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+    if (heapRanges.TotalActiveRangeCount < baseRanges.TotalActiveRangeCount + 1)
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+
+    BOOL foundHeapRange = FALSE;
+    for (uint32_t idx = 0; idx < heapRanges.ReturnedRangeCount; ++idx)
+    {
+        if (heapRanges.Ranges[idx].Arena == KE_KVA_ARENA_HEAP && heapRanges.Ranges[idx].UsableBase == heapVirt)
+        {
+            foundHeapRange = TRUE;
+            break;
+        }
+    }
+    if (!foundHeapRange && !heapRanges.Truncated)
     {
         status = EC_INVALID_STATE;
         goto cleanup;
@@ -149,9 +227,13 @@ RunMemoryObservabilitySelfTest(void)
     status = KiQueryVmmOverview(&finalVmm);
     if (status != EC_SUCCESS)
         goto cleanup;
+    status = KiQueryActiveKvaRanges(&finalRanges);
+    if (status != EC_SUCCESS)
+        goto cleanup;
 
     if (finalPhysical.TotalBytes != basePhysical.TotalBytes || finalPhysical.FreeBytes != basePhysical.FreeBytes ||
-        finalPhysical.AllocatedBytes != basePhysical.AllocatedBytes || finalPhysical.ReservedBytes != basePhysical.ReservedBytes)
+        finalPhysical.AllocatedBytes != basePhysical.AllocatedBytes ||
+        finalPhysical.ReservedBytes != basePhysical.ReservedBytes)
     {
         status = EC_INVALID_STATE;
         goto cleanup;
@@ -171,9 +253,16 @@ RunMemoryObservabilitySelfTest(void)
         status = EC_INVALID_STATE;
         goto cleanup;
     }
+    if (finalRanges.TotalActiveRangeCount != baseRanges.TotalActiveRangeCount ||
+        finalRanges.ReturnedRangeCount != baseRanges.ReturnedRangeCount ||
+        finalRanges.Truncated != baseRanges.Truncated)
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
 
-    klog(KLOG_LEVEL_INFO,
-         "[OBS] memory observability self-test OK: pmm/vmm counters tracked fixmap+heap activity and recovered\n");
+    klog(KLOG_LEVEL_INFO, "[OBS] memory observability self-test OK: pmm/vmm counters and bounded KVA snapshots tracked "
+                          "fixmap+heap activity\n");
     return EC_SUCCESS;
 
 cleanup:
@@ -187,8 +276,7 @@ cleanup:
         }
         else
         {
-            klog(KLOG_LEVEL_ERROR,
-                 "[OBS] cleanup preserved PMM page %p because temp-map release failed (%s, %p)\n",
+            klog(KLOG_LEVEL_ERROR, "[OBS] cleanup preserved PMM page %p because temp-map release failed (%s, %p)\n",
                  (void *)(uint64_t)tempPhys, KrGetStatusMessage(cleanupStatus), cleanupStatus);
         }
 
@@ -226,6 +314,41 @@ cleanup:
     }
 
     return status;
+}
+
+static HO_STATUS
+RunClockEventObservabilitySelfTest(void)
+{
+    SYSINFO_CLOCK_EVENT info = {0};
+    HO_STATUS status = KiQueryClockEventInfo(&info);
+    if (status != EC_SUCCESS)
+        return status;
+
+    if (!info.Ready || info.FreqHz == 0 || info.VectorNumber == 0 || info.SourceName[0] == '\0')
+        return EC_INVALID_STATE;
+
+    if (info.MinDeltaNs == 0 || info.MaxDeltaNs == 0 || info.MinDeltaNs > info.MaxDeltaNs)
+        return EC_INVALID_STATE;
+
+    return EC_SUCCESS;
+}
+
+static HO_STATUS
+RunSchedulerObservabilitySelfTest(void)
+{
+    KE_SYSINFO_SCHEDULER_DATA info = {0};
+    HO_STATUS status = KiQuerySchedulerInfo(&info);
+    if (status != EC_SUCCESS)
+        return status;
+
+    if (!info.SchedulerEnabled || info.CurrentThreadId != 0 || info.IdleThreadId != 0 || info.ReadyQueueDepth != 0 ||
+        info.SleepQueueDepth != 0 || info.EarliestWakeDeadline != 0 || info.NextProgrammedDeadline != 0 ||
+        info.ActiveThreadCount != 1 || info.TotalThreadsCreated != 1)
+    {
+        return EC_INVALID_STATE;
+    }
+
+    return EC_SUCCESS;
 }
 
 void
@@ -308,7 +431,8 @@ InitKernel(MAYBE_UNUSED STAGING_BLOCK *block)
             // Runtime RAM smoke test should use a temporary fixmap alias, not a persistent HHDM ownership address.
             KE_TEMP_PHYS_MAP_HANDLE tempMap = {0};
             HO_VIRTUAL_ADDRESS tempVirt = 0;
-            initStatus = KeTempPhysMapAcquire(testPage, PTE_WRITABLE | PTE_GLOBAL | PTE_NO_EXECUTE, &tempMap, &tempVirt);
+            initStatus =
+                KeTempPhysMapAcquire(testPage, PTE_WRITABLE | PTE_GLOBAL | PTE_NO_EXECUTE, &tempMap, &tempVirt);
             if (initStatus != EC_SUCCESS)
             {
                 (void)KePmmFreePages(testPage, 1);
@@ -355,6 +479,12 @@ InitKernel(MAYBE_UNUSED STAGING_BLOCK *block)
         HO_KPANIC(initStatus, "Failed to initialize clock event");
     }
 
+    initStatus = RunClockEventObservabilitySelfTest();
+    if (initStatus != EC_SUCCESS)
+    {
+        HO_KPANIC(initStatus, "Clock-event observability self-test failed");
+    }
+
     // ---- KTHREAD Object Pool ----
     // Depends on KeKvaInit(): KeKThreadPoolInit() -> KePoolInit() ->
     // KeHeapAllocPages().
@@ -387,6 +517,12 @@ InitKernel(MAYBE_UNUSED STAGING_BLOCK *block)
     if (initStatus != EC_SUCCESS)
     {
         HO_KPANIC(initStatus, "Failed to initialize scheduler");
+    }
+
+    initStatus = RunSchedulerObservabilitySelfTest();
+    if (initStatus != EC_SUCCESS)
+    {
+        HO_KPANIC(initStatus, "Scheduler observability self-test failed");
     }
 }
 

--- a/src/kernel/ke/mm/kva.c
+++ b/src/kernel/ke/mm/kva.c
@@ -7,29 +7,31 @@
  * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
  */
 
+#include <kernel/ke/critical_section.h>
 #include <kernel/ke/mm.h>
 #include <kernel/hodbg.h>
 #include <libc/string.h>
 
-#define KE_KVA_STACK_ARENA_BASE   HO_ALIGN_UP((KRNL_IST2_STACK_VA + HO_STACK_SIZE + PAGE_4KB), PAGE_2MB)
-#define KE_KVA_STACK_ARENA_SIZE   (32ULL * 1024ULL * 1024ULL)
-#define KE_KVA_HEAP_ARENA_BASE    HO_ALIGN_UP((KE_KVA_STACK_ARENA_BASE + KE_KVA_STACK_ARENA_SIZE), PAGE_2MB)
-#define KE_KVA_HEAP_ARENA_SIZE    (64ULL * 1024ULL * 1024ULL)
-#define KE_KVA_FIXMAP_ARENA_SIZE  (64ULL * PAGE_4KB)
-#define KE_KVA_FIXMAP_ARENA_BASE  (HHDM_BASE_VA - KE_KVA_FIXMAP_ARENA_SIZE)
+#define KE_KVA_STACK_ARENA_BASE           HO_ALIGN_UP((KRNL_IST2_STACK_VA + HO_STACK_SIZE + PAGE_4KB), PAGE_2MB)
+#define KE_KVA_STACK_ARENA_SIZE           (32ULL * 1024ULL * 1024ULL)
+#define KE_KVA_HEAP_ARENA_BASE            HO_ALIGN_UP((KE_KVA_STACK_ARENA_BASE + KE_KVA_STACK_ARENA_SIZE), PAGE_2MB)
+#define KE_KVA_HEAP_ARENA_SIZE            (64ULL * 1024ULL * 1024ULL)
+#define KE_KVA_FIXMAP_ARENA_SIZE          (64ULL * PAGE_4KB)
+#define KE_KVA_FIXMAP_ARENA_BASE          (HHDM_BASE_VA - KE_KVA_FIXMAP_ARENA_SIZE)
 
-#define KE_KVA_STACK_ARENA_PAGES  (KE_KVA_STACK_ARENA_SIZE / PAGE_4KB)
-#define KE_KVA_FIXMAP_ARENA_PAGES (KE_KVA_FIXMAP_ARENA_SIZE / PAGE_4KB)
-#define KE_KVA_HEAP_ARENA_PAGES   (KE_KVA_HEAP_ARENA_SIZE / PAGE_4KB)
+#define KE_KVA_STACK_ARENA_PAGES          (KE_KVA_STACK_ARENA_SIZE / PAGE_4KB)
+#define KE_KVA_FIXMAP_ARENA_PAGES         (KE_KVA_FIXMAP_ARENA_SIZE / PAGE_4KB)
+#define KE_KVA_HEAP_ARENA_PAGES           (KE_KVA_HEAP_ARENA_SIZE / PAGE_4KB)
 
-#define KE_KVA_MAX_RANGES         512U
-#define KE_KVA_PAGE_STATE_FREE    0U
-#define KE_KVA_PAGE_STATE_ALLOC   1U
-#define KE_KVA_PAGE_STATE_GUARD   2U
-#define KE_KVA_DEFAULT_PAGE_ATTRS (PTE_WRITABLE | PTE_GLOBAL | PTE_NO_EXECUTE)
+#define KE_KVA_MAX_RANGES                 512U
+#define KE_KVA_PAGE_STATE_FREE            0U
+#define KE_KVA_PAGE_STATE_ALLOC           1U
+#define KE_KVA_PAGE_STATE_GUARD           2U
+#define KE_KVA_PAGE_STATE_RETIRED         3U
+#define KE_KVA_DEFAULT_PAGE_ATTRS         (PTE_WRITABLE | PTE_GLOBAL | PTE_NO_EXECUTE)
 #define KE_TEMP_MAP_TOKEN_SLOT_BITS       6U
-#define KE_TEMP_MAP_TOKEN_SLOT_MASK       ((1U << KE_TEMP_MAP_TOKEN_SLOT_BITS) - 1U)
-#define KE_TEMP_MAP_TOKEN_GENERATION_MASK 0x03FFFFFFU
+#define KE_TEMP_MAP_TOKEN_SLOT_MASK       ((1ULL << KE_TEMP_MAP_TOKEN_SLOT_BITS) - 1ULL)
+#define KE_TEMP_MAP_TOKEN_GENERATION_MASK ((1ULL << (64U - KE_TEMP_MAP_TOKEN_SLOT_BITS)) - 1ULL)
 
 typedef struct KE_KVA_ARENA_STATE
 {
@@ -46,6 +48,7 @@ typedef struct KE_KVA_RANGE_RECORD
     BOOL OwnsPhysicalBacking;
     KE_KVA_ARENA_TYPE Arena;
     uint32_t RecordId;
+    uint64_t Generation;
     uint64_t BasePageIndex;
     uint64_t TotalPages;
     uint64_t UsablePages;
@@ -58,7 +61,8 @@ static KE_KVA_RANGE_RECORD gKvaRanges[KE_KVA_MAX_RANGES];
 static uint8_t gStackArenaStates[KE_KVA_STACK_ARENA_PAGES];
 static uint8_t gFixmapArenaStates[KE_KVA_FIXMAP_ARENA_PAGES];
 static uint8_t gHeapArenaStates[KE_KVA_HEAP_ARENA_PAGES];
-static uint32_t gFixmapSlotGenerations[KE_KVA_FIXMAP_ARENA_PAGES];
+static uint64_t gFixmapSlotGenerations[KE_KVA_FIXMAP_ARENA_PAGES];
+static uint64_t gKvaRangeGenerationCounter = 1ULL;
 static BOOL gKvaInitialized = FALSE;
 
 static inline KE_KVA_ARENA_STATE *
@@ -75,6 +79,27 @@ KiKvaRecordUsableBase(const KE_KVA_ARENA_STATE *arena, const KE_KVA_RANGE_RECORD
     return arena->BaseAddress + (record->BasePageIndex + record->GuardLowerPages) * PAGE_4KB;
 }
 
+static inline BOOL
+KiKvaFixmapSlotRetired(uint64_t pageIndex)
+{
+    return pageIndex < KE_KVA_FIXMAP_ARENA_PAGES && gFixmapSlotGenerations[pageIndex] >= KE_TEMP_MAP_TOKEN_GENERATION_MASK;
+}
+
+static uint64_t
+KiKvaNextRangeGeneration(void)
+{
+    if (gKvaRangeGenerationCounter == 0)
+        return 0;
+
+    uint64_t generation = gKvaRangeGenerationCounter;
+    if (generation == 0xFFFFFFFFFFFFFFFFULL)
+        gKvaRangeGenerationCounter = 0;
+    else
+        gKvaRangeGenerationCounter++;
+
+    return generation;
+}
+
 static HO_STATUS
 KiKvaFillRangeFromRecord(const KE_KVA_RANGE_RECORD *record, KE_KVA_RANGE *outRange)
 {
@@ -88,12 +113,39 @@ KiKvaFillRangeFromRecord(const KE_KVA_RANGE_RECORD *record, KE_KVA_RANGE *outRan
     memset(outRange, 0, sizeof(*outRange));
     outRange->Arena = record->Arena;
     outRange->RecordId = record->RecordId;
+    outRange->Generation = record->Generation;
     outRange->BaseAddress = arena->BaseAddress + record->BasePageIndex * PAGE_4KB;
     outRange->UsableBase = KiKvaRecordUsableBase(arena, record);
     outRange->TotalPages = record->TotalPages;
     outRange->UsablePages = record->UsablePages;
     outRange->GuardLowerPages = record->GuardLowerPages;
     outRange->GuardUpperPages = record->GuardUpperPages;
+    return EC_SUCCESS;
+}
+
+static HO_STATUS
+KiKvaFillActiveRangeEntry(const KE_KVA_RANGE_RECORD *record, KE_KVA_ACTIVE_RANGE_ENTRY *outEntry)
+{
+    if (!record || !outEntry)
+        return EC_ILLEGAL_ARGUMENT;
+
+    KE_KVA_RANGE range;
+    HO_STATUS status = KiKvaFillRangeFromRecord(record, &range);
+    if (status != EC_SUCCESS)
+        return status;
+
+    memset(outEntry, 0, sizeof(*outEntry));
+    outEntry->Arena = range.Arena;
+    outEntry->RecordId = range.RecordId;
+    outEntry->Generation = range.Generation;
+    outEntry->BaseAddress = range.BaseAddress;
+    outEntry->EndAddressExclusive = range.BaseAddress + range.TotalPages * PAGE_4KB;
+    outEntry->UsableBase = range.UsableBase;
+    outEntry->UsableEndExclusive = range.UsableBase + range.UsablePages * PAGE_4KB;
+    outEntry->TotalPages = range.TotalPages;
+    outEntry->UsablePages = range.UsablePages;
+    outEntry->GuardLowerPages = range.GuardLowerPages;
+    outEntry->GuardUpperPages = range.GuardUpperPages;
     return EC_SUCCESS;
 }
 
@@ -181,15 +233,15 @@ KiKvaLocateArenaByAddress(HO_VIRTUAL_ADDRESS virtAddr,
 }
 
 static HO_STATUS
-KiDecodeTempMapHandle(const KE_TEMP_PHYS_MAP_HANDLE *handle, uint32_t *outSlot, uint32_t *outGeneration)
+KiDecodeTempMapHandle(const KE_TEMP_PHYS_MAP_HANDLE *handle, uint32_t *outSlot, uint64_t *outGeneration)
 {
     if (!handle || !outSlot || !outGeneration)
         return EC_ILLEGAL_ARGUMENT;
     if (handle->Token == 0)
         return EC_INVALID_STATE;
 
-    uint32_t slot = handle->Token & KE_TEMP_MAP_TOKEN_SLOT_MASK;
-    uint32_t generation = handle->Token >> KE_TEMP_MAP_TOKEN_SLOT_BITS;
+    uint32_t slot = (uint32_t)(handle->Token & KE_TEMP_MAP_TOKEN_SLOT_MASK);
+    uint64_t generation = handle->Token >> KE_TEMP_MAP_TOKEN_SLOT_BITS;
     if (slot >= KE_KVA_FIXMAP_ARENA_PAGES || generation == 0 || generation > KE_TEMP_MAP_TOKEN_GENERATION_MASK)
         return EC_ILLEGAL_ARGUMENT;
 
@@ -198,22 +250,20 @@ KiDecodeTempMapHandle(const KE_TEMP_PHYS_MAP_HANDLE *handle, uint32_t *outSlot, 
     return EC_SUCCESS;
 }
 
-static uint32_t
+static uint64_t
 KiNextFixmapSlotGeneration(uint32_t slot)
 {
     if (slot >= KE_KVA_FIXMAP_ARENA_PAGES)
         return 0;
+    if (gFixmapSlotGenerations[slot] >= KE_TEMP_MAP_TOKEN_GENERATION_MASK)
+        return 0;
 
-    uint32_t generation = (gFixmapSlotGenerations[slot] + 1U) & KE_TEMP_MAP_TOKEN_GENERATION_MASK;
-    if (generation == 0)
-        generation = 1U;
-
-    gFixmapSlotGenerations[slot] = generation;
-    return generation;
+    gFixmapSlotGenerations[slot]++;
+    return gFixmapSlotGenerations[slot];
 }
 
-static uint32_t
-KiEncodeTempMapToken(uint32_t slot, uint32_t generation)
+static uint64_t
+KiEncodeTempMapToken(uint32_t slot, uint64_t generation)
 {
     if (slot >= KE_KVA_FIXMAP_ARENA_PAGES)
         return 0;
@@ -228,20 +278,85 @@ KiKvaFindRecordById(const KE_KVA_RANGE *range)
 {
     if (!range || range->RecordId == 0 || range->RecordId > KE_KVA_MAX_RANGES)
         return NULL;
+    if (range->Generation == 0)
+        return NULL;
 
     KE_KVA_RANGE_RECORD *record = &gKvaRanges[range->RecordId - 1];
     if (!record->InUse)
         return NULL;
     if (record->Arena != range->Arena)
         return NULL;
+    if (record->Generation != range->Generation)
+        return NULL;
 
     KE_KVA_ARENA_STATE *arena = KiKvaArenaState(record->Arena);
     if (!arena)
         return NULL;
+    HO_VIRTUAL_ADDRESS baseAddress = arena->BaseAddress + record->BasePageIndex * PAGE_4KB;
+    if (baseAddress != range->BaseAddress)
+        return NULL;
     if (KiKvaRecordUsableBase(arena, record) != range->UsableBase)
         return NULL;
+    if (record->TotalPages != range->TotalPages || record->UsablePages != range->UsablePages ||
+        record->GuardLowerPages != range->GuardLowerPages || record->GuardUpperPages != range->GuardUpperPages)
+    {
+        return NULL;
+    }
 
     return record;
+}
+
+static HO_STATUS
+KiKvaReleaseRecord(KE_KVA_RANGE_RECORD *record, const KE_KVA_ARENA_STATE *arena)
+{
+    if (!record || !arena)
+        return EC_ILLEGAL_ARGUMENT;
+
+    HO_VIRTUAL_ADDRESS usableBase = KiKvaRecordUsableBase(arena, record);
+    BOOL teardownStarted = FALSE;
+    uint8_t releasedPageState = KE_KVA_PAGE_STATE_FREE;
+    if (record->Arena == KE_KVA_ARENA_FIXMAP && record->TotalPages == 1 && KiKvaFixmapSlotRetired(record->BasePageIndex))
+        releasedPageState = KE_KVA_PAGE_STATE_RETIRED;
+
+    for (uint64_t pageIdx = 0; pageIdx < record->UsablePages; ++pageIdx)
+    {
+        HO_VIRTUAL_ADDRESS virtAddr = usableBase + pageIdx * PAGE_4KB;
+        KE_PT_MAPPING mapping;
+        HO_STATUS status = KePtQueryPage(KeGetKernelAddressSpace(), virtAddr, &mapping);
+        if (status != EC_SUCCESS)
+        {
+            if (teardownStarted)
+                HO_KPANIC(status, "KVA teardown failed after partial progress");
+            return status;
+        }
+        if (!mapping.Present)
+            continue;
+        if (mapping.Level != 1)
+        {
+            if (teardownStarted)
+                HO_KPANIC(EC_NOT_SUPPORTED, "KVA teardown hit non-leaf mapping after partial progress");
+            return EC_NOT_SUPPORTED;
+        }
+
+        teardownStarted = TRUE;
+        status = KePtUnmapPage(KeGetKernelAddressSpace(), virtAddr);
+        if (status != EC_SUCCESS)
+            HO_KPANIC(status, "KVA teardown failed after unmapping started");
+
+        if (record->OwnsPhysicalBacking)
+        {
+            status = KePmmFreePages(mapping.PhysicalBase, 1);
+            if (status != EC_SUCCESS)
+                HO_KPANIC(status, "KVA teardown failed after physical free sequence started");
+        }
+    }
+
+    for (uint64_t pageIdx = 0; pageIdx < record->TotalPages; ++pageIdx)
+        arena->PageStates[record->BasePageIndex + pageIdx] = releasedPageState;
+
+    memset(record, 0, sizeof(*record));
+    record->RecordId = (uint32_t)(record - gKvaRanges) + 1;
+    return EC_SUCCESS;
 }
 
 static BOOL
@@ -376,6 +491,7 @@ KeKvaInit(void)
     for (uint32_t idx = 0; idx < KE_KVA_MAX_RANGES; ++idx)
         gKvaRanges[idx].RecordId = idx + 1;
     memset(gFixmapSlotGenerations, 0, sizeof(gFixmapSlotGenerations));
+    gKvaRangeGenerationCounter = 1ULL;
 
     gKvaInitialized = TRUE;
 
@@ -407,9 +523,18 @@ KeKvaAllocRange(KE_KVA_ARENA_TYPE arenaType,
     if (!arena)
         return EC_ILLEGAL_ARGUMENT;
 
-    uint64_t totalPages = guardLowerPages + usablePages + guardUpperPages;
+    if (guardLowerPages > 0xFFFFFFFFFFFFFFFFULL - usablePages)
+        return EC_OUT_OF_RESOURCE;
+    uint64_t totalPages = guardLowerPages + usablePages;
+    if (guardUpperPages > 0xFFFFFFFFFFFFFFFFULL - totalPages)
+        return EC_OUT_OF_RESOURCE;
+    totalPages += guardUpperPages;
     if (totalPages == 0 || totalPages > arena->PageCount)
         return EC_OUT_OF_RESOURCE;
+
+    KE_CRITICAL_SECTION criticalSection = {0};
+    HO_STATUS status = EC_OUT_OF_RESOURCE;
+    KeEnterCriticalSection(&criticalSection);
 
     KE_KVA_RANGE_RECORD *record = NULL;
     for (uint32_t idx = 0; idx < KE_KVA_MAX_RANGES; ++idx)
@@ -421,7 +546,7 @@ KeKvaAllocRange(KE_KVA_ARENA_TYPE arenaType,
         }
     }
     if (!record)
-        return EC_OUT_OF_RESOURCE;
+        goto cleanup;
 
     for (uint64_t basePage = 0; basePage + totalPages <= arena->PageCount; ++basePage)
     {
@@ -437,6 +562,13 @@ KeKvaAllocRange(KE_KVA_ARENA_TYPE arenaType,
         if (!available)
             continue;
 
+        uint64_t generation = KiKvaNextRangeGeneration();
+        if (generation == 0)
+        {
+            status = EC_OUT_OF_RESOURCE;
+            goto cleanup;
+        }
+
         for (uint64_t offset = 0; offset < totalPages; ++offset)
         {
             uint64_t pageIndex = basePage + offset;
@@ -445,20 +577,24 @@ KeKvaAllocRange(KE_KVA_ARENA_TYPE arenaType,
         }
 
         memset(record, 0, sizeof(*record));
-        record->InUse = TRUE;
         record->OwnsPhysicalBacking = ownsPhysicalBacking;
         record->Arena = arenaType;
         record->RecordId = (uint32_t)(record - gKvaRanges) + 1;
+        record->Generation = generation;
         record->BasePageIndex = basePage;
         record->TotalPages = totalPages;
         record->UsablePages = usablePages;
         record->GuardLowerPages = guardLowerPages;
         record->GuardUpperPages = guardUpperPages;
+        record->InUse = TRUE;
 
-        return KiKvaFillRangeFromRecord(record, outRange);
+        status = KiKvaFillRangeFromRecord(record, outRange);
+        goto cleanup;
     }
 
-    return EC_OUT_OF_RESOURCE;
+cleanup:
+    KeLeaveCriticalSection(&criticalSection);
+    return status;
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
@@ -469,14 +605,28 @@ KeKvaMapPage(const KE_KVA_RANGE *range, uint64_t usablePageIndex, HO_PHYSICAL_AD
     if (!range)
         return EC_ILLEGAL_ARGUMENT;
 
+    KE_CRITICAL_SECTION criticalSection = {0};
+    HO_STATUS status = EC_SUCCESS;
+    KeEnterCriticalSection(&criticalSection);
+
     KE_KVA_RANGE_RECORD *record = KiKvaFindRecordById(range);
     if (!record)
-        return EC_INVALID_STATE;
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
     if (usablePageIndex >= record->UsablePages)
-        return EC_ILLEGAL_ARGUMENT;
+    {
+        status = EC_ILLEGAL_ARGUMENT;
+        goto cleanup;
+    }
 
     HO_VIRTUAL_ADDRESS virtAddr = range->UsableBase + usablePageIndex * PAGE_4KB;
-    return KePtMapPage(KeGetKernelAddressSpace(), virtAddr, physAddr, attributes);
+    status = KePtMapPage(KeGetKernelAddressSpace(), virtAddr, physAddr, attributes);
+
+cleanup:
+    KeLeaveCriticalSection(&criticalSection);
+    return status;
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
@@ -487,17 +637,28 @@ KeKvaMapOwnedPages(const KE_KVA_RANGE *range, uint64_t attributes)
     if (!range)
         return EC_ILLEGAL_ARGUMENT;
 
+    KE_CRITICAL_SECTION criticalSection = {0};
+    HO_STATUS status = EC_SUCCESS;
+    uint64_t usablePages = 0;
+
+    KeEnterCriticalSection(&criticalSection);
     KE_KVA_RANGE_RECORD *record = KiKvaFindRecordById(range);
     if (!record || !record->OwnsPhysicalBacking)
-        return EC_INVALID_STATE;
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+    usablePages = record->UsablePages;
+    KeLeaveCriticalSection(&criticalSection);
+    criticalSection.Active = FALSE;
 
-    for (uint64_t pageIdx = 0; pageIdx < record->UsablePages; ++pageIdx)
+    for (uint64_t pageIdx = 0; pageIdx < usablePages; ++pageIdx)
     {
         HO_PHYSICAL_ADDRESS physAddr = 0;
-        HO_STATUS status = KePmmAllocPages(1, NULL, &physAddr);
+        status = KePmmAllocPages(1, NULL, &physAddr);
         if (status != EC_SUCCESS)
         {
-            HO_STATUS cleanupStatus = KeKvaReleaseRange(range->UsableBase);
+            HO_STATUS cleanupStatus = KeKvaReleaseRangeHandle(range);
             if (cleanupStatus != EC_SUCCESS)
                 return cleanupStatus;
             return status;
@@ -507,7 +668,7 @@ KeKvaMapOwnedPages(const KE_KVA_RANGE *range, uint64_t attributes)
         if (status != EC_SUCCESS)
         {
             (void)KePmmFreePages(physAddr, 1);
-            HO_STATUS cleanupStatus = KeKvaReleaseRange(range->UsableBase);
+            HO_STATUS cleanupStatus = KeKvaReleaseRangeHandle(range);
             if (cleanupStatus != EC_SUCCESS)
                 return cleanupStatus;
             return status;
@@ -515,6 +676,43 @@ KeKvaMapOwnedPages(const KE_KVA_RANGE *range, uint64_t attributes)
     }
 
     return EC_SUCCESS;
+
+cleanup:
+    KeLeaveCriticalSection(&criticalSection);
+    return status;
+}
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS
+KeKvaReleaseRangeHandle(const KE_KVA_RANGE *range)
+{
+    if (!gKvaInitialized)
+        return EC_INVALID_STATE;
+    if (!range)
+        return EC_ILLEGAL_ARGUMENT;
+
+    KE_CRITICAL_SECTION criticalSection = {0};
+    HO_STATUS status = EC_SUCCESS;
+    KeEnterCriticalSection(&criticalSection);
+
+    KE_KVA_RANGE_RECORD *record = KiKvaFindRecordById(range);
+    if (!record)
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+
+    KE_KVA_ARENA_STATE *arena = KiKvaArenaState(record->Arena);
+    if (!arena)
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+
+    status = KiKvaReleaseRecord(record, arena);
+
+cleanup:
+    KeLeaveCriticalSection(&criticalSection);
+    return status;
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
@@ -525,44 +723,29 @@ KeKvaReleaseRange(HO_VIRTUAL_ADDRESS usableBase)
     if (!HO_IS_ALIGNED(usableBase, PAGE_4KB))
         return EC_ILLEGAL_ARGUMENT;
 
+    KE_CRITICAL_SECTION criticalSection = {0};
+    HO_STATUS status = EC_SUCCESS;
+    KeEnterCriticalSection(&criticalSection);
+
     KE_KVA_RANGE_RECORD *record = KiKvaFindRecordByUsableBase(usableBase);
     if (!record)
-        return EC_INVALID_STATE;
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
 
     KE_KVA_ARENA_STATE *arena = KiKvaArenaState(record->Arena);
     if (!arena)
-        return EC_INVALID_STATE;
-
-    for (uint64_t pageIdx = 0; pageIdx < record->UsablePages; ++pageIdx)
     {
-        HO_VIRTUAL_ADDRESS virtAddr = usableBase + pageIdx * PAGE_4KB;
-        KE_PT_MAPPING mapping;
-        HO_STATUS status = KePtQueryPage(KeGetKernelAddressSpace(), virtAddr, &mapping);
-        if (status != EC_SUCCESS)
-            return status;
-        if (!mapping.Present)
-            continue;
-        if (mapping.Level != 1)
-            return EC_NOT_SUPPORTED;
-
-        status = KePtUnmapPage(KeGetKernelAddressSpace(), virtAddr);
-        if (status != EC_SUCCESS)
-            return status;
-
-        if (record->OwnsPhysicalBacking)
-        {
-            status = KePmmFreePages(mapping.PhysicalBase, 1);
-            if (status != EC_SUCCESS)
-                return status;
-        }
+        status = EC_INVALID_STATE;
+        goto cleanup;
     }
 
-    for (uint64_t pageIdx = 0; pageIdx < record->TotalPages; ++pageIdx)
-        arena->PageStates[record->BasePageIndex + pageIdx] = KE_KVA_PAGE_STATE_FREE;
+    status = KiKvaReleaseRecord(record, arena);
 
-    memset(record, 0, sizeof(*record));
-    record->RecordId = (uint32_t)(record - gKvaRanges) + 1;
-    return EC_SUCCESS;
+cleanup:
+    KeLeaveCriticalSection(&criticalSection);
+    return status;
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
@@ -573,11 +756,22 @@ KeKvaQueryRange(HO_VIRTUAL_ADDRESS usableBase, KE_KVA_RANGE *outRange)
     if (!outRange)
         return EC_ILLEGAL_ARGUMENT;
 
+    KE_CRITICAL_SECTION criticalSection = {0};
+    HO_STATUS status = EC_SUCCESS;
+    KeEnterCriticalSection(&criticalSection);
+
     KE_KVA_RANGE_RECORD *record = KiKvaFindRecordByUsableBase(usableBase);
     if (!record)
-        return EC_INVALID_STATE;
+    {
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
 
-    return KiKvaFillRangeFromRecord(record, outRange);
+    status = KiKvaFillRangeFromRecord(record, outRange);
+
+cleanup:
+    KeLeaveCriticalSection(&criticalSection);
+    return status;
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
@@ -588,9 +782,16 @@ KeKvaQueryArenaInfo(KE_KVA_ARENA_TYPE arenaType, KE_KVA_ARENA_INFO *outInfo)
     if (!outInfo)
         return EC_ILLEGAL_ARGUMENT;
 
+    KE_CRITICAL_SECTION criticalSection = {0};
+    HO_STATUS status = EC_SUCCESS;
+    KeEnterCriticalSection(&criticalSection);
+
     KE_KVA_ARENA_STATE *arena = KiKvaArenaState(arenaType);
     if (!arena)
-        return EC_ILLEGAL_ARGUMENT;
+    {
+        status = EC_ILLEGAL_ARGUMENT;
+        goto cleanup;
+    }
 
     memset(outInfo, 0, sizeof(*outInfo));
     outInfo->Arena = arenaType;
@@ -601,7 +802,10 @@ KeKvaQueryArenaInfo(KE_KVA_ARENA_TYPE arenaType, KE_KVA_ARENA_INFO *outInfo)
     outInfo->ActiveAllocations = KiKvaCountActiveRanges(arenaType);
     outInfo->OverlapsImportedRegions = KiKvaArenaOverlapsImportedRegions(
         KeGetKernelAddressSpace(), outInfo->BaseAddress, outInfo->EndAddressExclusive);
-    return EC_SUCCESS;
+
+cleanup:
+    KeLeaveCriticalSection(&criticalSection);
+    return status;
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
@@ -612,11 +816,57 @@ KeKvaQueryUsageInfo(KE_KVA_USAGE_INFO *outInfo)
     if (!outInfo)
         return EC_ILLEGAL_ARGUMENT;
 
+    KE_CRITICAL_SECTION criticalSection = {0};
+    KeEnterCriticalSection(&criticalSection);
+
     memset(outInfo, 0, sizeof(*outInfo));
     outInfo->ActiveRangeCount = KiKvaCountAllActiveRanges();
     outInfo->FixmapTotalSlots = gKvaArenas[KE_KVA_ARENA_FIXMAP].PageCount;
     outInfo->FixmapActiveSlots = KiKvaCountActiveRanges(KE_KVA_ARENA_FIXMAP);
+    KeLeaveCriticalSection(&criticalSection);
     return EC_SUCCESS;
+}
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS
+KeKvaQueryActiveRanges(KE_KVA_ACTIVE_RANGE_SNAPSHOT *outSnapshot)
+{
+    if (!gKvaInitialized)
+        return EC_INVALID_STATE;
+    if (!outSnapshot)
+        return EC_ILLEGAL_ARGUMENT;
+
+    KE_CRITICAL_SECTION criticalSection = {0};
+    HO_STATUS status = EC_SUCCESS;
+    KeEnterCriticalSection(&criticalSection);
+
+    memset(outSnapshot, 0, sizeof(*outSnapshot));
+    outSnapshot->TotalActiveRangeCount = KiKvaCountAllActiveRanges();
+
+    uint32_t returned = 0;
+    for (uint32_t idx = 0; idx < KE_KVA_MAX_RANGES; ++idx)
+    {
+        if (!gKvaRanges[idx].InUse)
+            continue;
+
+        if (returned >= KE_KVA_ACTIVE_RANGE_SNAPSHOT_MAX)
+        {
+            outSnapshot->Truncated = TRUE;
+            break;
+        }
+
+        status = KiKvaFillActiveRangeEntry(&gKvaRanges[idx], &outSnapshot->Ranges[returned]);
+        if (status != EC_SUCCESS)
+            goto cleanup;
+
+        returned++;
+    }
+
+    outSnapshot->ReturnedRangeCount = returned;
+    outSnapshot->Truncated = outSnapshot->Truncated || (returned < outSnapshot->TotalActiveRangeCount);
+
+cleanup:
+    KeLeaveCriticalSection(&criticalSection);
+    return status;
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
@@ -627,6 +877,10 @@ KeKvaClassifyAddress(HO_VIRTUAL_ADDRESS virtAddr, KE_KVA_ADDRESS_INFO *outInfo)
     if (!outInfo)
         return EC_ILLEGAL_ARGUMENT;
 
+    KE_CRITICAL_SECTION criticalSection = {0};
+    HO_STATUS status = EC_SUCCESS;
+    KeEnterCriticalSection(&criticalSection);
+
     memset(outInfo, 0, sizeof(*outInfo));
     outInfo->Kind = KE_KVA_ADDRESS_OUTSIDE;
     outInfo->Arena = KE_KVA_ARENA_MAX;
@@ -635,7 +889,7 @@ KeKvaClassifyAddress(HO_VIRTUAL_ADDRESS virtAddr, KE_KVA_ADDRESS_INFO *outInfo)
     KE_KVA_ARENA_STATE *arena = NULL;
     uint64_t pageIndex = 0;
     if (!KiKvaLocateArenaByAddress(virtAddr, &arenaType, &arena, &pageIndex))
-        return EC_SUCCESS;
+        goto cleanup;
 
     outInfo->InKvaArena = TRUE;
     outInfo->Arena = arenaType;
@@ -647,7 +901,7 @@ KeKvaClassifyAddress(HO_VIRTUAL_ADDRESS virtAddr, KE_KVA_ADDRESS_INFO *outInfo)
     if (pageState == KE_KVA_PAGE_STATE_FREE)
     {
         outInfo->Kind = KE_KVA_ADDRESS_FREE_HOLE;
-        return EC_SUCCESS;
+        goto cleanup;
     }
 
     KE_KVA_RANGE_RECORD *record = KiKvaFindRecordByAddress(arenaType, virtAddr);
@@ -665,28 +919,34 @@ KeKvaClassifyAddress(HO_VIRTUAL_ADDRESS virtAddr, KE_KVA_ADDRESS_INFO *outInfo)
         {
             outInfo->Kind = KE_KVA_ADDRESS_UNKNOWN;
         }
-        return EC_INVALID_STATE;
+        status = EC_INVALID_STATE;
+        goto cleanup;
     }
 
-    HO_STATUS status = KiKvaFillRangeFromRecord(record, &outInfo->Range);
+    status = KiKvaFillRangeFromRecord(record, &outInfo->Range);
     if (status != EC_SUCCESS)
-        return status;
+        goto cleanup;
     outInfo->HasRange = TRUE;
 
     if (pageState == KE_KVA_PAGE_STATE_GUARD)
     {
         outInfo->Kind = KE_KVA_ADDRESS_GUARD_PAGE;
-        return EC_SUCCESS;
+        goto cleanup;
     }
 
     if (pageState == KE_KVA_PAGE_STATE_ALLOC)
     {
         outInfo->Kind = KiKvaAddressKindFromArena(arenaType);
-        return outInfo->Kind == KE_KVA_ADDRESS_UNKNOWN ? EC_INVALID_STATE : EC_SUCCESS;
+        status = outInfo->Kind == KE_KVA_ADDRESS_UNKNOWN ? EC_INVALID_STATE : EC_SUCCESS;
+        goto cleanup;
     }
 
     outInfo->Kind = KE_KVA_ADDRESS_UNKNOWN;
-    return EC_INVALID_STATE;
+    status = EC_INVALID_STATE;
+
+cleanup:
+    KeLeaveCriticalSection(&criticalSection);
+    return status;
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
@@ -706,54 +966,111 @@ KeKvaValidateLayout(void)
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
-KeFixmapAcquire(HO_PHYSICAL_ADDRESS physAddr, uint64_t attributes, uint32_t *outSlot, HO_VIRTUAL_ADDRESS *outVirtAddr)
+KeFixmapAcquire(HO_PHYSICAL_ADDRESS physAddr,
+                uint64_t attributes,
+                KE_TEMP_PHYS_MAP_HANDLE *outHandle,
+                HO_VIRTUAL_ADDRESS *outVirtAddr)
 {
     if (!gKvaInitialized)
         return EC_INVALID_STATE;
-    if (!outSlot || !outVirtAddr || !HO_IS_ALIGNED(physAddr, PAGE_4KB))
+    if (!outHandle || !outVirtAddr || !HO_IS_ALIGNED(physAddr, PAGE_4KB))
         return EC_ILLEGAL_ARGUMENT;
 
-    KE_KVA_RANGE range;
-    HO_STATUS status = KeKvaAllocRange(KE_KVA_ARENA_FIXMAP, 1, 0, 0, FALSE, &range);
-    if (status != EC_SUCCESS)
-        return status;
+    outHandle->Token = 0;
+    *outVirtAddr = 0;
 
-    status = KeKvaMapPage(&range, 0, physAddr, attributes);
-    if (status != EC_SUCCESS)
+    KE_CRITICAL_SECTION criticalSection = {0};
+    HO_STATUS status = EC_OUT_OF_RESOURCE;
+    KeEnterCriticalSection(&criticalSection);
+
+    KE_KVA_RANGE_RECORD *record = NULL;
+    uint32_t slot = 0;
+    for (uint32_t idx = 0; idx < KE_KVA_MAX_RANGES; ++idx)
     {
-        HO_STATUS cleanupStatus = KeKvaReleaseRange(range.UsableBase);
-        if (cleanupStatus != EC_SUCCESS)
-            return cleanupStatus;
-        return status;
+        if (!gKvaRanges[idx].InUse)
+        {
+            record = &gKvaRanges[idx];
+            break;
+        }
+    }
+    if (!record)
+        goto cleanup;
+
+    KE_KVA_ARENA_STATE *arena = &gKvaArenas[KE_KVA_ARENA_FIXMAP];
+    for (slot = 0; slot < arena->PageCount; ++slot)
+    {
+        if (arena->PageStates[slot] != KE_KVA_PAGE_STATE_FREE)
+            continue;
+        if (KiKvaFixmapSlotRetired(slot))
+        {
+            arena->PageStates[slot] = KE_KVA_PAGE_STATE_RETIRED;
+            continue;
+        }
+
+        uint64_t generation = KiNextFixmapSlotGeneration(slot);
+        if (generation == 0)
+        {
+            arena->PageStates[slot] = KE_KVA_PAGE_STATE_RETIRED;
+            continue;
+        }
+
+        arena->PageStates[slot] = KE_KVA_PAGE_STATE_ALLOC;
+        memset(record, 0, sizeof(*record));
+        record->OwnsPhysicalBacking = FALSE;
+        record->Arena = KE_KVA_ARENA_FIXMAP;
+        record->RecordId = (uint32_t)(record - gKvaRanges) + 1;
+        record->Generation = generation;
+        record->BasePageIndex = slot;
+        record->TotalPages = 1;
+        record->UsablePages = 1;
+        record->GuardLowerPages = 0;
+        record->GuardUpperPages = 0;
+        record->InUse = TRUE;
+
+        KE_KVA_RANGE range;
+        status = KiKvaFillRangeFromRecord(record, &range);
+        if (status != EC_SUCCESS)
+        {
+            arena->PageStates[slot] = KE_KVA_PAGE_STATE_FREE;
+            memset(record, 0, sizeof(*record));
+            record->RecordId = (uint32_t)(record - gKvaRanges) + 1;
+            goto cleanup;
+        }
+
+        outHandle->Token = KiEncodeTempMapToken(slot, generation);
+        if (outHandle->Token == 0)
+        {
+            arena->PageStates[slot] = KE_KVA_PAGE_STATE_FREE;
+            memset(record, 0, sizeof(*record));
+            record->RecordId = (uint32_t)(record - gKvaRanges) + 1;
+            status = EC_INVALID_STATE;
+            goto cleanup;
+        }
+
+        status = KePtMapPage(KeGetKernelAddressSpace(), range.UsableBase, physAddr, attributes);
+        if (status != EC_SUCCESS)
+        {
+            outHandle->Token = 0;
+            arena->PageStates[slot] = KE_KVA_PAGE_STATE_FREE;
+            memset(record, 0, sizeof(*record));
+            record->RecordId = (uint32_t)(record - gKvaRanges) + 1;
+            goto cleanup;
+        }
+
+        *outVirtAddr = range.UsableBase;
+        status = EC_SUCCESS;
+        goto cleanup;
     }
 
-    *outSlot = (uint32_t)((range.UsableBase - KE_KVA_FIXMAP_ARENA_BASE) / PAGE_4KB);
-    if (KiNextFixmapSlotGeneration(*outSlot) == 0)
-    {
-        HO_STATUS cleanupStatus = KeKvaReleaseRange(range.UsableBase);
-        if (cleanupStatus != EC_SUCCESS)
-            return cleanupStatus;
-        return EC_INVALID_STATE;
-    }
-
-    *outVirtAddr = range.UsableBase;
-    return EC_SUCCESS;
+cleanup:
+    KeLeaveCriticalSection(&criticalSection);
+    return status;
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
-KeFixmapRelease(uint32_t slot)
+KeFixmapRelease(KE_TEMP_PHYS_MAP_HANDLE *handle)
 {
-    if (!gKvaInitialized)
-        return EC_INVALID_STATE;
-    if (slot >= KE_KVA_FIXMAP_ARENA_PAGES)
-        return EC_ILLEGAL_ARGUMENT;
-
-    HO_VIRTUAL_ADDRESS usableBase = KE_KVA_FIXMAP_ARENA_BASE + (uint64_t)slot * PAGE_4KB;
-    KE_KVA_RANGE_RECORD *record = KiKvaFindRecordByUsableBase(usableBase);
-    if (!record || record->Arena != KE_KVA_ARENA_FIXMAP)
-        return EC_INVALID_STATE;
-
-    return KeKvaReleaseRange(usableBase);
+    return KeTempPhysMapRelease(handle);
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
@@ -765,22 +1082,9 @@ KeTempPhysMapAcquire(HO_PHYSICAL_ADDRESS physAddr,
     if (!outHandle || !outVirtAddr || !HO_IS_ALIGNED(physAddr, PAGE_4KB))
         return EC_ILLEGAL_ARGUMENT;
 
-    uint32_t slot = 0;
-    HO_STATUS status = KeFixmapAcquire(physAddr, attributes, &slot, outVirtAddr);
-    if (status != EC_SUCCESS)
-        return status;
-
-    uint32_t generation = gFixmapSlotGenerations[slot];
-    outHandle->Token = KiEncodeTempMapToken(slot, generation);
-    if (outHandle->Token == 0)
-    {
-        HO_STATUS cleanupStatus = KeFixmapRelease(slot);
-        if (cleanupStatus != EC_SUCCESS)
-            return cleanupStatus;
-        return EC_INVALID_STATE;
-    }
-
-    return EC_SUCCESS;
+    outHandle->Token = 0;
+    *outVirtAddr = 0;
+    return KeFixmapAcquire(physAddr, attributes, outHandle, outVirtAddr);
 }
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
@@ -790,19 +1094,29 @@ KeTempPhysMapRelease(KE_TEMP_PHYS_MAP_HANDLE *handle)
         return EC_ILLEGAL_ARGUMENT;
 
     uint32_t slot = 0;
-    uint32_t generation = 0;
+    uint64_t generation = 0;
     HO_STATUS status = KiDecodeTempMapHandle(handle, &slot, &generation);
     if (status != EC_SUCCESS)
         return status;
 
+    KE_CRITICAL_SECTION criticalSection = {0};
+    KeEnterCriticalSection(&criticalSection);
+
     HO_VIRTUAL_ADDRESS usableBase = KE_KVA_FIXMAP_ARENA_BASE + (uint64_t)slot * PAGE_4KB;
     KE_KVA_RANGE_RECORD *record = KiKvaFindRecordByUsableBase(usableBase);
     if (!record || record->Arena != KE_KVA_ARENA_FIXMAP)
+    {
+        KeLeaveCriticalSection(&criticalSection);
         return EC_INVALID_STATE;
+    }
     if (gFixmapSlotGenerations[slot] != generation)
+    {
+        KeLeaveCriticalSection(&criticalSection);
         return EC_INVALID_STATE;
+    }
 
-    status = KeFixmapRelease(slot);
+    status = KiKvaReleaseRecord(record, KiKvaArenaState(record->Arena));
+    KeLeaveCriticalSection(&criticalSection);
     if (status == EC_SUCCESS)
         handle->Token = 0;
     return status;
@@ -867,7 +1181,7 @@ KeKvaSelfTest(void)
     if (!mapping.Present || mapping.Level != 1)
         return EC_INVALID_STATE;
 
-    status = KeKvaReleaseRange(stackRange.UsableBase);
+    status = KeKvaReleaseRangeHandle(&stackRange);
     if (status != EC_SUCCESS)
         return status;
 
@@ -880,8 +1194,8 @@ KeKvaSelfTest(void)
     volatile uint64_t *alias = (volatile uint64_t *)(uint64_t)HHDM_PHYS2VIRT(testPhys);
     *alias = 0x6B56414649584D50ULL;
 
-    uint32_t slotA = 0;
-    uint32_t slotB = 0;
+    KE_TEMP_PHYS_MAP_HANDLE fixHandleA = {0};
+    KE_TEMP_PHYS_MAP_HANDLE fixHandleB = {0};
     HO_VIRTUAL_ADDRESS fixVirtA = 0;
     HO_VIRTUAL_ADDRESS fixVirtB = 0;
     KE_TEMP_PHYS_MAP_HANDLE tempHandleA = {0};
@@ -892,7 +1206,7 @@ KeKvaSelfTest(void)
     HO_VIRTUAL_ADDRESS reusedTempVirt = 0;
     HO_VIRTUAL_ADDRESS heapVirt = 0;
 
-    status = KeFixmapAcquire(testPhys, KE_KVA_DEFAULT_PAGE_ATTRS, &slotA, &fixVirtA);
+    status = KeFixmapAcquire(testPhys, KE_KVA_DEFAULT_PAGE_ATTRS, &fixHandleA, &fixVirtA);
     if (status != EC_SUCCESS)
         goto cleanup_fixmap_phys;
 
@@ -903,12 +1217,12 @@ KeKvaSelfTest(void)
         goto cleanup_fixmap_slot_a;
     }
 
-    status = KeFixmapRelease(slotA);
+    status = KeFixmapRelease(&fixHandleA);
     if (status != EC_SUCCESS)
         goto cleanup_fixmap_phys;
     fixVirtA = 0;
 
-    status = KeFixmapAcquire(testPhys, KE_KVA_DEFAULT_PAGE_ATTRS, &slotB, &fixVirtB);
+    status = KeFixmapAcquire(testPhys, KE_KVA_DEFAULT_PAGE_ATTRS, &fixHandleB, &fixVirtB);
     if (status != EC_SUCCESS)
         goto cleanup_fixmap_phys;
 
@@ -919,7 +1233,7 @@ KeKvaSelfTest(void)
         goto cleanup_fixmap_slot_b;
     }
 
-    status = KeFixmapRelease(slotB);
+    status = KeFixmapRelease(&fixHandleB);
     if (status != EC_SUCCESS)
         goto cleanup_fixmap_phys;
     fixVirtB = 0;
@@ -1005,7 +1319,8 @@ KeKvaSelfTest(void)
         return status;
     testPhys = 0;
 
-    klog(KLOG_LEVEL_INFO, "[KVA] self-test OK: guard pages, fixmap reuse, temp-map ownership, and heap growth verified\n");
+    klog(KLOG_LEVEL_INFO,
+         "[KVA] self-test OK: guard pages, fixmap reuse, temp-map ownership, and heap growth verified\n");
     return EC_SUCCESS;
 
 cleanup_heap:
@@ -1058,7 +1373,7 @@ cleanup_temp_map_a:
 cleanup_fixmap_slot_b:
     if (fixVirtB != 0)
     {
-        HO_STATUS cleanupStatus = KeFixmapRelease(slotB);
+        HO_STATUS cleanupStatus = KeFixmapRelease(&fixHandleB);
         if (cleanupStatus == EC_SUCCESS)
         {
             fixVirtB = 0;
@@ -1066,8 +1381,8 @@ cleanup_fixmap_slot_b:
         else
         {
             klog(KLOG_LEVEL_ERROR,
-                 "[KVA] self-test cleanup preserved PMM page %p because fixmap slot %lu release failed (%s, %p)\n",
-                 (void *)(uint64_t)testPhys, (unsigned long)slotB, KrGetStatusMessage(cleanupStatus), cleanupStatus);
+                 "[KVA] self-test cleanup preserved PMM page %p because fixmap handle B release failed (%s, %p)\n",
+                 (void *)(uint64_t)testPhys, KrGetStatusMessage(cleanupStatus), cleanupStatus);
             if (status == EC_SUCCESS)
                 status = cleanupStatus;
         }
@@ -1075,7 +1390,7 @@ cleanup_fixmap_slot_b:
 cleanup_fixmap_slot_a:
     if (fixVirtA != 0)
     {
-        HO_STATUS cleanupStatus = KeFixmapRelease(slotA);
+        HO_STATUS cleanupStatus = KeFixmapRelease(&fixHandleA);
         if (cleanupStatus == EC_SUCCESS)
         {
             fixVirtA = 0;
@@ -1083,8 +1398,8 @@ cleanup_fixmap_slot_a:
         else
         {
             klog(KLOG_LEVEL_ERROR,
-                 "[KVA] self-test cleanup preserved PMM page %p because fixmap slot %lu release failed (%s, %p)\n",
-                 (void *)(uint64_t)testPhys, (unsigned long)slotA, KrGetStatusMessage(cleanupStatus), cleanupStatus);
+                 "[KVA] self-test cleanup preserved PMM page %p because fixmap handle A release failed (%s, %p)\n",
+                 (void *)(uint64_t)testPhys, KrGetStatusMessage(cleanupStatus), cleanupStatus);
             if (status == EC_SUCCESS)
                 status = cleanupStatus;
         }
@@ -1100,7 +1415,8 @@ cleanup_fixmap_phys:
         }
         else
         {
-            klog(KLOG_LEVEL_ERROR, "[KVA] self-test preserved PMM page %p because a fixmap/temp alias is still active\n",
+            klog(KLOG_LEVEL_ERROR,
+                 "[KVA] self-test preserved PMM page %p because a fixmap/temp alias is still active\n",
                  (void *)(uint64_t)testPhys);
         }
     }

--- a/src/kernel/ke/mm/pool.c
+++ b/src/kernel/ke/mm/pool.c
@@ -8,32 +8,110 @@
  */
 
 #include <kernel/ke/pool.h>
+#include <kernel/ke/critical_section.h>
 #include <kernel/ke/mm.h>
 #include <kernel/hodefs.h>
 #include <kernel/hodbg.h>
 #include <libc/string.h>
 
-static HO_STATUS
-KiPoolExpandOnePage(KE_POOL *pool)
+typedef struct KE_POOL_PREPARED_PAGE
 {
+    HO_VIRTUAL_ADDRESS BaseVirt;
+    KE_POOL_FREE_NODE *Head;
+    KE_POOL_FREE_NODE *Tail;
+    uint32_t SlotCount;
+} KE_POOL_PREPARED_PAGE;
+
+static HO_STATUS
+KiPoolPrepareOnePage(KE_POOL *pool, KE_POOL_PREPARED_PAGE *page)
+{
+    page->BaseVirt = 0;
+    page->Head = NULL;
+    page->Tail = NULL;
+    page->SlotCount = 0;
+
     // Pool backing now comes from the KVA heap foundation instead of directly
     // from PMM, so KeKvaInit() must have completed before any pool can grow.
-    HO_VIRTUAL_ADDRESS baseVirt;
-    HO_STATUS status = KeHeapAllocPages(1, &baseVirt);
+    HO_STATUS status = KeHeapAllocPages(1, &page->BaseVirt);
     if (status != EC_SUCCESS)
         return status;
 
-    uint8_t *base = (uint8_t *)(uint64_t)baseVirt;
+    uint8_t *base = (uint8_t *)(uint64_t)page->BaseVirt;
 
     for (uint32_t i = 0; i < pool->SlotsPerPage; i++)
     {
         KE_POOL_FREE_NODE *node = (KE_POOL_FREE_NODE *)(base + i * pool->SlotSize);
-        node->Next = pool->FreeList;
-        pool->FreeList = node;
-        pool->TotalSlots++;
+        node->Next = page->Head;
+        page->Head = node;
+        if (page->Tail == NULL)
+            page->Tail = node;
+        page->SlotCount++;
     }
 
     return EC_SUCCESS;
+}
+
+static void
+KiPoolPublishPreparedPage(KE_POOL *pool, KE_POOL_PREPARED_PAGE *page)
+{
+    KE_CRITICAL_SECTION criticalSection = {0};
+
+    HO_KASSERT(page->Head != NULL, EC_INVALID_STATE);
+    HO_KASSERT(page->Tail != NULL, EC_INVALID_STATE);
+    HO_KASSERT(page->SlotCount != 0, EC_INVALID_STATE);
+
+    KeEnterCriticalSection(&criticalSection);
+    page->Tail->Next = pool->FreeList;
+    pool->FreeList = page->Head;
+    pool->TotalSlots += page->SlotCount;
+    KeLeaveCriticalSection(&criticalSection);
+}
+
+static KE_POOL_FREE_NODE *
+KiPoolTryPopNode(KE_POOL *pool)
+{
+    KE_CRITICAL_SECTION criticalSection = {0};
+    KE_POOL_FREE_NODE *node;
+
+    KeEnterCriticalSection(&criticalSection);
+
+    node = pool->FreeList;
+    if (node != NULL)
+    {
+        pool->FreeList = node->Next;
+        pool->UsedSlots++;
+        HO_KASSERT(pool->UsedSlots <= pool->TotalSlots, EC_INVALID_STATE);
+    }
+
+    KeLeaveCriticalSection(&criticalSection);
+    return node;
+}
+
+static KE_POOL_FREE_NODE *
+KiPoolPublishPreparedPageAndPop(KE_POOL *pool, KE_POOL_PREPARED_PAGE *page)
+{
+    KE_CRITICAL_SECTION criticalSection = {0};
+    KE_POOL_FREE_NODE *node;
+
+    HO_KASSERT(page->Head != NULL, EC_INVALID_STATE);
+    HO_KASSERT(page->Tail != NULL, EC_INVALID_STATE);
+    HO_KASSERT(page->SlotCount != 0, EC_INVALID_STATE);
+
+    KeEnterCriticalSection(&criticalSection);
+
+    page->Tail->Next = pool->FreeList;
+    pool->FreeList = page->Head;
+    pool->TotalSlots += page->SlotCount;
+
+    node = pool->FreeList;
+    HO_KASSERT(node != NULL, EC_INVALID_STATE);
+
+    pool->FreeList = node->Next;
+    pool->UsedSlots++;
+    HO_KASSERT(pool->UsedSlots <= pool->TotalSlots, EC_INVALID_STATE);
+
+    KeLeaveCriticalSection(&criticalSection);
+    return node;
 }
 
 HO_KERNEL_API HO_STATUS
@@ -62,9 +140,12 @@ KePoolInit(KE_POOL *pool, size_t objectSize, uint32_t initialCapacity, const cha
 
     for (uint32_t i = 0; i < neededPages; i++)
     {
-        HO_STATUS status = KiPoolExpandOnePage(pool);
+        KE_POOL_PREPARED_PAGE page;
+        HO_STATUS status = KiPoolPrepareOnePage(pool, &page);
         if (status != EC_SUCCESS)
             return status;
+
+        KiPoolPublishPreparedPage(pool, &page);
     }
 
     klog(KLOG_LEVEL_INFO, "[POOL] \"%s\" ready: slotSize=%lu slots=%u pages=%u\n", name, (unsigned long)slotSize,
@@ -75,15 +156,16 @@ KePoolInit(KE_POOL *pool, size_t objectSize, uint32_t initialCapacity, const cha
 HO_KERNEL_API void *
 KePoolAlloc(KE_POOL *pool)
 {
-    if (pool->FreeList == NULL)
-    {
-        if (KiPoolExpandOnePage(pool) != EC_SUCCESS)
-            return NULL;
-    }
+    KE_POOL_FREE_NODE *node = KiPoolTryPopNode(pool);
 
-    KE_POOL_FREE_NODE *node = pool->FreeList;
-    pool->FreeList = node->Next;
-    pool->UsedSlots++;
+    if (node == NULL)
+    {
+        KE_POOL_PREPARED_PAGE page;
+        if (KiPoolPrepareOnePage(pool, &page) != EC_SUCCESS)
+            return NULL;
+
+        node = KiPoolPublishPreparedPageAndPop(pool, &page);
+    }
 
     memset(node, 0, pool->SlotSize);
     return (void *)node;
@@ -95,8 +177,13 @@ KePoolFree(KE_POOL *pool, void *object)
     if (!object)
         return;
 
+    KE_CRITICAL_SECTION criticalSection = {0};
     KE_POOL_FREE_NODE *node = (KE_POOL_FREE_NODE *)object;
+
+    KeEnterCriticalSection(&criticalSection);
+    HO_KASSERT(pool->UsedSlots != 0, EC_INVALID_STATE);
     node->Next = pool->FreeList;
     pool->FreeList = node;
     pool->UsedSlots--;
+    KeLeaveCriticalSection(&criticalSection);
 }

--- a/src/kernel/ke/sysinfo/memory.c
+++ b/src/kernel/ke/sysinfo/memory.c
@@ -162,3 +162,46 @@ QueryVmmOverview(void *Buffer, size_t BufferSize, size_t *RequiredSize)
     info->FixmapActiveSlots = usageInfo.FixmapActiveSlots;
     return EC_SUCCESS;
 }
+
+HO_STATUS
+QueryActiveKvaRanges(void *Buffer, size_t BufferSize, size_t *RequiredSize)
+{
+    const size_t required = sizeof(SYSINFO_ACTIVE_KVA_RANGES);
+
+    if (RequiredSize)
+        *RequiredSize = required;
+
+    if (!Buffer)
+        return EC_SUCCESS;
+
+    if (BufferSize < required)
+        return EC_NOT_ENOUGH_MEMORY;
+
+    KE_KVA_ACTIVE_RANGE_SNAPSHOT snapshot;
+    HO_STATUS status = KeKvaQueryActiveRanges(&snapshot);
+    if (status != EC_SUCCESS)
+        return status;
+
+    SYSINFO_ACTIVE_KVA_RANGES *info = (SYSINFO_ACTIVE_KVA_RANGES *)Buffer;
+    memset(info, 0, sizeof(*info));
+    info->TotalActiveRangeCount = snapshot.TotalActiveRangeCount;
+    info->ReturnedRangeCount = snapshot.ReturnedRangeCount;
+    info->Truncated = snapshot.Truncated;
+
+    for (uint32_t idx = 0; idx < snapshot.ReturnedRangeCount; ++idx)
+    {
+        info->Ranges[idx].Arena = snapshot.Ranges[idx].Arena;
+        info->Ranges[idx].RecordId = snapshot.Ranges[idx].RecordId;
+        info->Ranges[idx].Generation = snapshot.Ranges[idx].Generation;
+        info->Ranges[idx].BaseAddress = snapshot.Ranges[idx].BaseAddress;
+        info->Ranges[idx].EndAddressExclusive = snapshot.Ranges[idx].EndAddressExclusive;
+        info->Ranges[idx].UsableBase = snapshot.Ranges[idx].UsableBase;
+        info->Ranges[idx].UsableEndExclusive = snapshot.Ranges[idx].UsableEndExclusive;
+        info->Ranges[idx].TotalPages = snapshot.Ranges[idx].TotalPages;
+        info->Ranges[idx].UsablePages = snapshot.Ranges[idx].UsablePages;
+        info->Ranges[idx].GuardLowerPages = snapshot.Ranges[idx].GuardLowerPages;
+        info->Ranges[idx].GuardUpperPages = snapshot.Ranges[idx].GuardUpperPages;
+    }
+
+    return EC_SUCCESS;
+}

--- a/src/kernel/ke/sysinfo/sysinfo.c
+++ b/src/kernel/ke/sysinfo/sysinfo.c
@@ -115,6 +115,9 @@ KeQuerySystemInformation(KE_SYSINFO_CLASS Class, void *Buffer, size_t BufferSize
     case KE_SYSINFO_VMM_OVERVIEW:
         return QueryVmmOverview(Buffer, BufferSize, RequiredSize);
 
+    case KE_SYSINFO_ACTIVE_KVA_RANGES:
+        return QueryActiveKvaRanges(Buffer, BufferSize, RequiredSize);
+
     default:
         return EC_ILLEGAL_ARGUMENT;
     }

--- a/src/kernel/ke/sysinfo/sysinfo_internal.h
+++ b/src/kernel/ke/sysinfo/sysinfo_internal.h
@@ -68,3 +68,4 @@ HO_STATUS QueryUptime(void *Buffer, size_t BufferSize, size_t *RequiredSize);
 HO_STATUS QuerySystemVersion(void *Buffer, size_t BufferSize, size_t *RequiredSize);
 HO_STATUS QueryClockEvent(void *Buffer, size_t BufferSize, size_t *RequiredSize);
 HO_STATUS QueryScheduler(void *Buffer, size_t BufferSize, size_t *RequiredSize);
+HO_STATUS QueryActiveKvaRanges(void *Buffer, size_t BufferSize, size_t *RequiredSize);

--- a/src/kernel/ke/sysinfo/time.c
+++ b/src/kernel/ke/sysinfo/time.c
@@ -108,6 +108,8 @@ QueryClockEvent(void *Buffer, size_t BufferSize, size_t *RequiredSize)
 
     info->FreqHz = KeClockEventGetFrequency();
     info->InterruptCount = KeClockEventGetInterruptCount();
+    info->MinDeltaNs = KeClockEventGetMinDeltaNs();
+    info->MaxDeltaNs = KeClockEventGetMaxDeltaNs();
     info->VectorNumber = KeClockEventGetVector();
 
     const char *name = KeClockEventGetSourceName();

--- a/src/kernel/ke/thread/kthread.c
+++ b/src/kernel/ke/thread/kthread.c
@@ -87,6 +87,7 @@ KeThreadCreate(KTHREAD **outThread, KTHREAD_ENTRY entryPoint, void *arg)
     thread->StackSize = KE_THREAD_STACK_SIZE;
     thread->StackGuardBase = stackRange.BaseAddress;
     thread->StackOwnedByKva = TRUE;
+    thread->StackRange = stackRange;
 
     thread->Priority = 0;
     thread->Quantum = KE_DEFAULT_QUANTUM_NS;

--- a/src/kernel/ke/thread/kthread.c
+++ b/src/kernel/ke/thread/kthread.c
@@ -8,6 +8,7 @@
  */
 
 #include <kernel/ke/kthread.h>
+#include <kernel/ke/critical_section.h>
 #include <kernel/ke/irql.h>
 #include <kernel/ke/scheduler.h>
 #include <kernel/ke/mm.h>
@@ -30,6 +31,20 @@ static uint32_t gNextThreadId = 1;
 
 extern void KiThreadTrampoline(void);
 
+static uint32_t
+KiAllocateThreadId(void)
+{
+    KE_CRITICAL_SECTION criticalSection = {0};
+    uint32_t threadId;
+
+    KeEnterCriticalSection(&criticalSection);
+    HO_KASSERT(gNextThreadId != 0, EC_OUT_OF_RESOURCE);
+    threadId = gNextThreadId++;
+    KeLeaveCriticalSection(&criticalSection);
+
+    return threadId;
+}
+
 // ─────────────────────────────────────────────────────────────
 // Pool init
 // ─────────────────────────────────────────────────────────────
@@ -45,6 +60,8 @@ KeThreadCreate(KTHREAD **outThread, KTHREAD_ENTRY entryPoint, void *arg)
 {
     if (!outThread || !entryPoint)
         return EC_ILLEGAL_ARGUMENT;
+
+    *outThread = NULL;
 
     KTHREAD *thread = (KTHREAD *)KePoolAlloc(&gKThreadPool);
     if (!thread)
@@ -76,7 +93,7 @@ KeThreadCreate(KTHREAD **outThread, KTHREAD_ENTRY entryPoint, void *arg)
     *sp = (uint64_t)KiThreadTrampoline; // RET target for KiSwitchContext
 
     // Initialize KTHREAD
-    thread->ThreadId = gNextThreadId++;
+    thread->ThreadId = KiAllocateThreadId();
     thread->State = KTHREAD_STATE_NEW;
 
     memset(&thread->Context, 0, sizeof(KTHREAD_CONTEXT));

--- a/src/kernel/ke/thread/scheduler/diag.c
+++ b/src/kernel/ke/thread/scheduler/diag.c
@@ -34,12 +34,17 @@ KeQuerySchedulerInfo(KE_SYSINFO_SCHEDULER_DATA *out)
     if (!out)
         return EC_ILLEGAL_ARGUMENT;
 
+    KE_CRITICAL_SECTION criticalSection = {0};
+    KeEnterCriticalSection(&criticalSection);
     memset(out, 0, sizeof(*out));
 
     out->SchedulerEnabled = gSchedulerEnabled;
 
     if (!gSchedulerEnabled)
+    {
+        KeLeaveCriticalSection(&criticalSection);
         return EC_SUCCESS;
+    }
 
     out->CurrentThreadId = gCurrentThread ? gCurrentThread->ThreadId : 0;
     out->IdleThreadId = gIdleThread ? gIdleThread->ThreadId : 0;
@@ -60,5 +65,6 @@ KeQuerySchedulerInfo(KE_SYSINFO_SCHEDULER_DATA *out)
     out->TotalThreadsCreated = gStats.TotalThreadsCreated;
     out->ActiveThreadCount = gStats.ActiveThreadCount;
 
+    KeLeaveCriticalSection(&criticalSection);
     return EC_SUCCESS;
 }

--- a/src/kernel/ke/thread/scheduler/scheduler.c
+++ b/src/kernel/ke/thread/scheduler/scheduler.c
@@ -67,6 +67,7 @@ KeSchedulerInit(void)
     gIdleThread->StackSize = HO_STACK_SIZE;
     gIdleThread->StackGuardBase = 0;
     gIdleThread->StackOwnedByKva = FALSE;
+    memset(&gIdleThread->StackRange, 0, sizeof(gIdleThread->StackRange));
     gIdleThread->Priority = 0;
     gIdleThread->Quantum = 0;
     gIdleThread->OwnedMutexCount = 0;
@@ -322,7 +323,7 @@ KiReapTerminatedThreads(void)
 
         if (thread->StackOwnedByKva)
         {
-            HO_STATUS status = KeKvaReleaseRange(thread->StackBase);
+            HO_STATUS status = KeKvaReleaseRangeHandle(&thread->StackRange);
             if (status != EC_SUCCESS)
             {
                 HO_KPANIC(status, "Failed to release terminated KTHREAD stack");

--- a/src/kernel/ke/thread/scheduler/wait.c
+++ b/src/kernel/ke/thread/scheduler/wait.c
@@ -130,7 +130,8 @@ KiCompleteWait(KWAIT_BLOCK *block, HO_STATUS status)
     KTHREAD *thread = CONTAINING_RECORD(block, KTHREAD, WaitBlock);
     thread->State = KTHREAD_STATE_READY;
     LinkedListInsertTail(&gReadyQueue, &thread->ReadyLink);
-    gStats.SleepWakeCount++;
+    if (status == EC_TIMEOUT)
+        gStats.SleepWakeCount++;
 
     klog(KLOG_LEVEL_DEBUG, "[SCHED] Thread %u wait completed (%s)\n", thread->ThreadId,
          status == EC_SUCCESS ? "signaled" : "timeout");


### PR DESCRIPTION
## What Changed
- synchronized `KE_POOL` free-list and accounting updates used by KTHREAD allocation paths
- serialized `ThreadId` assignment during concurrent thread creation
- added the `kthread_pool_race` regression suite and wired it into the test menu/build

## Why
Concurrent thread creation was racing on the shared KTHREAD pool state and on `gNextThreadId`, which could corrupt pool accounting or hand out duplicate thread IDs.

## Impact
- hardens KTHREAD creation/allocation under the current UP critical-section model
- adds a focused regression profile for future scheduler and pool changes

## Validation
- `make kernel BUILD_FLAVOR=review-uncommitted -j4`
- `QEMU_DISPLAY=none BUILD_FLAVOR=test-kthread-pool-race-review HO_DEMO_TEST_NAME=kthread_pool_race HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_KTHREAD_POOL_RACE bash scripts/qemu_capture.sh 45 /tmp/himuos-kthread_pool_race_review.log`
- runtime log reached `KTHREAD pool race regression suite passed` before the watchdog stopped idle QEMU
