### PR TITLE
bootstrap minimal user mode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,7 @@ BUILD_FLAVOR=<flavor> HO_DEMO_TEST_NAME=<profile> HO_DEMO_TEST_DEFINE=<define> \
 | Profile | Build flavor | Define | Outcome class | Intent |
 | ------ | ------ | ------ | ------ | ------ |
 | `schedule` | `test-schedule` | `HO_DEMO_TEST_SCHEDULE` | clean pass with continued boot/idle | scheduler smoke coverage, thread/event/semaphore/mutex 基线路径 |
+| `user_hello` | `test-user_hello` | `HO_DEMO_TEST_USER_HELLO` | bootstrap-only minimal user-mode bring-up | 最小 Ring 3 进入、`int 0x80` raw syscall（`SYS_RAW_WRITE` / `SYS_RAW_EXIT`）与 idle/reaper 回收证据链 |
 | `guard_wait` | `test-guard_wait` | `HO_DEMO_TEST_GUARD_WAIT` | diagnosable contract violation or panic | critical-section guard misuse |
 | `owned_exit` | `test-owned_exit` | `HO_DEMO_TEST_OWNED_EXIT` | diagnosable contract violation or panic | exit while owning a mutex |
 | `irql_wait` | `test-irql_wait` | `HO_DEMO_TEST_IRQL_WAIT` | diagnosable contract violation or panic | wait at `DISPATCH_LEVEL` |
@@ -73,6 +74,8 @@ BUILD_FLAVOR=<flavor> HO_DEMO_TEST_NAME=<profile> HO_DEMO_TEST_DEFINE=<define> \
 | `pf_fixmap` | `test-pf_fixmap` | `HO_DEMO_TEST_PF_FIXMAP` | intentional fatal page-fault halt with bounded diagnostics | active fixmap alias diagnosis |
 | `pf_heap` | `test-pf_heap` | `HO_DEMO_TEST_PF_HEAP` | intentional fatal page-fault halt with bounded diagnostics | heap-backed KVA diagnosis |
 
+其中 `user_hello` 是 bootstrap-only 的最小用户态 bring-up profile，用来固定“进入用户态 -> `int 0x80` -> `SYS_RAW_WRITE` -> `SYS_RAW_EXIT` -> idle/reaper 回收”的证据链。它刻意复用当前 staging/imported-root 模型，因此**不是**最终进程地址空间合同，也不代表 Ex / handle-oriented 用户态接口已经定型。
+
 ### 例子
 
 ```bash
@@ -81,6 +84,12 @@ make clean
 bear -- make all BUILD_FLAVOR=test-schedule HO_DEMO_TEST_NAME=schedule HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_SCHEDULE
 BUILD_FLAVOR=test-schedule HO_DEMO_TEST_NAME=schedule HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_SCHEDULE \
     bash scripts/qemu_capture.sh 30 /tmp/himuos-schedule.log
+
+# bootstrap-only user-mode bring-up profile
+make clean
+bear -- make all BUILD_FLAVOR=test-user_hello HO_DEMO_TEST_NAME=user_hello HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_USER_HELLO
+BUILD_FLAVOR=test-user_hello HO_DEMO_TEST_NAME=user_hello HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_USER_HELLO \
+    bash scripts/qemu_capture.sh 30 /tmp/himuos-user-hello.log
 
 # guard-misuse profile
 make clean

--- a/docs/current-ability.md
+++ b/docs/current-ability.md
@@ -22,7 +22,7 @@
 
 ## 当前已支持的功能
 
-整体上，HimuOS 当前已经是一个**以 Ke 层为主的教学原型系统**：启动、内存、时间、控制台、中断、调度、同步、诊断、回归 profile 都已经具备明确实现。
+整体上，HimuOS 当前已经是一个**以 Ke 层为主、并带有一条 bootstrap-only 最小用户态切片的教学原型系统**：启动、内存、时间、控制台、中断、调度、同步、诊断、回归 profile 都已经具备明确实现；另外，独立 `user_hello` profile 已打通最小 Ring 3 bring-up 与 raw syscall 证据链，但这还不能等同于完整用户态子系统。
 
 | 能力域 | 结论 | 主要依据 |
 | --- | --- | --- |
@@ -44,6 +44,8 @@
 | 固定大小对象池 | 已有 | `src/kernel/ke/mm/pool.c`、`src/include/kernel/ke/pool.h`，OpenSpec `kernel-object-pool` |
 | 系统信息查询（sysinfo） | 已有 | `src/kernel/ke/sysinfo/sysinfo.c`、`src/include/kernel/ke/sysinfo.h`，已支持 CPU、页表、内存、GDT/TSS/IDT、时间、scheduler、VMM 等查询 |
 | 内核线程（KTHREAD） | 已有 | `src/kernel/ke/thread/kthread.c`、`src/include/kernel/ke/kthread.h`，支持创建 joinable / detached 线程 |
+| bootstrap-only 最小用户态执行路径 | 已有 | `src/kernel/demo/user_hello.c`、`src/kernel/ke/user_bootstrap.c`、`src/arch/amd64/user_bootstrap.asm`、`src/kernel/ke/thread/scheduler/scheduler.c` 已打通独立 `user_hello` profile 下的 staging 用户映射、首次进入 Ring 3 与回到内核的最小闭环 |
+| 最小 raw syscall 入口 | 已有 | `src/include/kernel/ke/user_bootstrap.h`、`src/kernel/ke/user_bootstrap_syscall.c`、`src/kernel/init/init.c` 已实现同步 `int 0x80` 入口与 `SYS_RAW_WRITE` / `SYS_RAW_EXIT` |
 | 调度器 | 已有 | `src/kernel/ke/thread/scheduler/scheduler.c`、`timer.c`、`diag.c`，OpenSpec `scheduler` / `scheduler-observability` |
 | 单对象等待模型 | 已有 | `src/kernel/ke/thread/scheduler/wait.c`，提供 `KeWaitForSingleObject` 与统一 wait-completion 路径，OpenSpec `dispatcher-objects` |
 | 事件（KEVENT） | 已有 | `src/kernel/ke/thread/scheduler/sync.c`、`src/include/kernel/ke/event.h`、OpenSpec `kevent` |
@@ -58,7 +60,9 @@
 
 如果用一句话概括当前系统状态，可以认为：
 
-> **HimuOS 当前已经完成了一个相当完整的 Ke 层教学原型。**
+> **HimuOS 当前已经完成了一个以 Ke 层为主、带有 bootstrap-only 最小用户态 bring-up 切片的教学原型。**
+
+这里的用户态能力只指独立 `user_hello` profile 下的最小执行路径与 raw syscall 入口，不应外推为完整进程地址空间、正式系统调用子系统或 Ex 层对象模型。
 
 它已经不只是“能启动的内核骨架”，而是具备以下连续能力链：
 
@@ -67,6 +71,7 @@
 3. 内核带起时间源、clock event、scheduler
 4. 调度器能驱动 KTHREAD、wait、event、semaphore、mutex
 5. 系统具备 sysinfo / 诊断 / regression profile 这些教学友好的观测入口
+6. 独立 `user_hello` profile 能把受控 payload 送入 Ring 3，并通过 `int 0x80` 完成 `SYS_RAW_WRITE` / `SYS_RAW_EXIT` 的最小证据链
 
 ## 有地基，但还不能算“该功能已经有”
 
@@ -74,7 +79,7 @@
 
 | 项目 | 现状 | 为什么还不能算“已有” |
 | --- | --- | --- |
-| Ring 3 GDT 段 | 有痕迹 | `src/arch/amd64/pm.c` 中已经建了 user code/data segment，但没有真正的用户态线程、用户态地址空间切换或返回 Ring 3 的执行路径 |
+| 正式用户态子系统 / 进程模型 | 只有 bootstrap bring-up | 当前已有独立 `user_hello` profile、staging 用户映射、Ring 3 入口和 raw syscall 闭环，但仍复用 imported root，不具备正式进程对象、独立进程地址空间或可恢复的用户 fault 模型 |
 | 键盘输入 | 只有 bootloader 级输入 | `src/boot/v2/io.c` 能通过 UEFI `ReadKeyStroke` 读取控制台输入，但这只是 bootloader 输入，不是 README 承诺的“内核键盘循环缓冲输入” |
 | handle 语义 | 只在局部存在 | KVA/fixmap 使用了 opaque handle/token，但这不是 README 所说的 Ex 层 capability handle / object handle 模型 |
 
@@ -84,9 +89,9 @@
 
 | 待完成功能 | 为什么仍算缺口 | 现有状态 |
 | --- | --- | --- |
-| 用户态执行路径（Ring 3 真正落地） | README 明确承诺“内核态与用户态安全隔离” | 目前只有 Ring 3 段描述符地基，没有用户态线程/进程运行入口 |
-| 用户态地址空间 / 进程级地址空间切换 | README 把虚拟内存目标描述为“为内核和用户程序提供隔离地址空间” | 当前内存管理几乎全部围绕 imported kernel root 与 KVA，没有进程地址空间模型 |
-| 系统调用入口 | README 明确承诺“系统调用是用户态获取内核服务的唯一入口” | 代码中没有 `syscall/sysret`、`int 0x80`、LSTAR 等系统调用通路实现 |
+| 完整用户态子系统 / 通用用户程序模型 | README 明确承诺“内核态与用户态安全隔离” | 当前只有挂在独立 `user_hello` profile 下的 bootstrap-only 最小执行路径，尚不具备通用用户程序装载、可恢复故障或稳定用户对象模型 |
+| 正式进程地址空间 / 进程级地址空间切换 | README 把虚拟内存目标描述为“为内核和用户程序提供隔离地址空间” | 当前用户页仍以 staging 方式挂在 imported root 上，不是正式进程地址空间模型 |
+| handle-oriented 正式 syscall 表面 | README 明确承诺“系统调用是用户态获取内核服务的唯一入口” | 当前只有同步 `int 0x80` 的 bootstrap raw syscall 入口，且 ABI 仅限 `SYS_RAW_WRITE` / `SYS_RAW_EXIT`，还不是正式的 handle-oriented syscall 接口 |
 | Ex 层 / Object Manager | README 明确写了 Ke/Ex 两层结构，Ex 层负责对象管理器 | 当前仓库基本只有 Ke 层；没有独立的 Ex 层目录、对象管理器或对象命名/生命周期框架 |
 | Capability 句柄模型 | README 把它作为用户态/内核态隔离的重要机制 | 当前没有对象句柄表、capability 校验、句柄引用/销毁等子系统 |
 | 优先级调度 | README 承诺“基于优先级和时间片轮转（RR）的调度器” | 当前 OpenSpec `scheduler` 与代码都明确是**单优先级 RR**；`KTHREAD.Priority` 只是保留字段 |
@@ -104,6 +109,6 @@
 当前的 HimuOS 更准确的定位是：
 
 - **已经完成的部分**：UEFI 启动、Ke 层核心机制、内核内存管理、线程调度与同步、诊断与教学回归 profile
-- **尚未完成的部分**：README 中更接近“完整 OS 对外语义”的那一层，尤其是用户态、系统调用、Ex/Object Manager、capability handle、键盘输入、优先级调度
+- **尚未完成的部分**：README 中更接近“完整 OS 对外语义”的那一层，尤其是正式进程地址空间、handle-oriented syscall、Ex/Object Manager、capability handle、键盘输入、优先级调度
 
-换句话说，当前系统已经是一个**功能明确、结构清晰的内核教学原型**，但还**不是** README 最初叙述里的那个“具备用户态/系统调用/Ex 层对象模型”的更完整版本。
+换句话说，当前系统已经是一个**功能明确、结构清晰的内核教学原型**，其中还带有一条 bootstrap-only 的最小用户态 bring-up 路径；但它还**不是** README 最初叙述里的那个“具备正式进程地址空间 / handle-oriented syscall / Ex 层对象模型”的更完整版本。

--- a/makefile
+++ b/makefile
@@ -83,7 +83,7 @@ KRN_BUILDROOT := build/kernel$(if $(strip $(BUILD_FLAVOR)),/$(BUILD_FLAVOR),)
 KRN_OBJDIR    := $(KRN_BUILDROOT)/obj
 KRN_BINDIR    := $(KRN_BUILDROOT)/bin
 
-VALID_TEST_MODULES := schedule guard_wait owned_exit irql_wait irql_sleep irql_yield irql_exit pf_imported pf_guard pf_fixmap pf_heap kthread_pool_race list
+VALID_TEST_MODULES := schedule guard_wait owned_exit irql_wait irql_sleep irql_yield irql_exit pf_imported pf_guard pf_fixmap pf_heap kthread_pool_race user_hello list
 TEST_MODULE_GOALS  := $(filter-out test,$(MAKECMDGOALS))
 TEST_MODULE        := $(if $(strip $(TEST_MODULE_GOALS)),$(firstword $(TEST_MODULE_GOALS)),list)
 TEST_BUILD_FLAVOR  := test-$(TEST_MODULE)
@@ -100,14 +100,15 @@ TEST_DEFINE_pf_guard := HO_DEMO_TEST_PF_GUARD
 TEST_DEFINE_pf_fixmap := HO_DEMO_TEST_PF_FIXMAP
 TEST_DEFINE_pf_heap := HO_DEMO_TEST_PF_HEAP
 TEST_DEFINE_kthread_pool_race := HO_DEMO_TEST_KTHREAD_POOL_RACE
+TEST_DEFINE_user_hello := HO_DEMO_TEST_USER_HELLO
 
 ifneq ($(filter test,$(MAKECMDGOALS)),)
 ifneq ($(words $(TEST_MODULE_GOALS)),0)
 ifneq ($(words $(TEST_MODULE_GOALS)),1)
-$(error Usage: make test <module>. Available modules: schedule, guard_wait, owned_exit, irql_wait, irql_sleep, irql_yield, irql_exit, pf_imported, pf_guard, pf_fixmap, pf_heap, kthread_pool_race. Use `make test` or `make test list` to inspect supported modules)
+$(error Usage: make test <module>. Available modules: schedule, guard_wait, owned_exit, irql_wait, irql_sleep, irql_yield, irql_exit, pf_imported, pf_guard, pf_fixmap, pf_heap, kthread_pool_race, user_hello. Use `make test` or `make test list` to inspect supported modules)
 endif
 ifneq ($(filter $(TEST_MODULE),$(VALID_TEST_MODULES)), $(TEST_MODULE))
-$(error Unknown test module '$(TEST_MODULE)'. Available modules: schedule, guard_wait, owned_exit, irql_wait, irql_sleep, irql_yield, irql_exit, pf_imported, pf_guard, pf_fixmap, pf_heap, kthread_pool_race. Use `make test list` to inspect supported modules)
+$(error Unknown test module '$(TEST_MODULE)'. Available modules: schedule, guard_wait, owned_exit, irql_wait, irql_sleep, irql_yield, irql_exit, pf_imported, pf_guard, pf_fixmap, pf_heap, kthread_pool_race, user_hello. Use `make test list` to inspect supported modules)
 endif
 endif
 endif
@@ -186,6 +187,7 @@ SRCS_KERNEL_C := \
 	src/kernel/demo/kthread_pool_race.c                 \
     src/kernel/demo/semaphore.c                         \
     src/kernel/demo/thread.c                            \
+	src/kernel/demo/user_hello.c                        \
     src/kernel/init/cpu.c                               \
     src/kernel/init/font.c                              \
     src/kernel/init/hhdm.c                              \
@@ -216,6 +218,8 @@ SRCS_KERNEL_C := \
     src/kernel/ke/mm/kva.c                              \
     src/kernel/ke/mm/allocator.c                        \
     src/kernel/ke/mm/pool.c                             \
+	src/kernel/ke/user_bootstrap.c                      \
+	src/kernel/ke/user_bootstrap_syscall.c              \
     src/kernel/ke/thread/kthread.c                      \
     src/kernel/ke/thread/scheduler/scheduler.c          \
     src/kernel/ke/thread/scheduler/wait.c               \
@@ -239,7 +243,8 @@ SRCS_KERNEL_C := \
 
 SRCS_KERNEL_ASM := \
     src/arch/amd64/intr_stub.asm \
-    src/arch/amd64/context_switch.asm
+	src/arch/amd64/context_switch.asm \
+	src/arch/amd64/user_bootstrap.asm
 
 # Kernel target: kernel sources + full libc + elf
 SRCS_KERNEL_ALL := $(SRCS_KERNEL_C) $(SRCS_LIBC) $(SRCS_ELF) $(SRCS_KERNEL_ASM)
@@ -329,6 +334,7 @@ ifeq ($(TEST_MODULE),list)
 	@echo "  pf_fixmap   - page-fault demo: NX execute fault in active fixmap slot"
 	@echo "  pf_heap     - page-fault demo: NX execute fault in heap-backed KVA page"
 	@echo "  kthread_pool_race - regression suite for KTHREAD pool synchronization"
+	@echo "  user_hello  - staged minimal user-mode bootstrap profile scaffold"
 	@echo "Recommended explicit workflow:"
 	@echo "  make clean"
 	@echo "  # schedule"
@@ -344,13 +350,14 @@ ifeq ($(TEST_MODULE),list)
 	@echo "  make test irql_wait  # run a dispatch-guard misuse panic regression"
 	@echo "  make test pf_heap    # run heap-backed page-fault observability demo"
 	@echo "  make test kthread_pool_race # run the KTHREAD pool race regression suite"
+	@echo "  make test user_hello # select the staged minimal user-mode bootstrap profile"
 	@echo "  make test            # list available test modules"
 else
 	@echo "Starting test module: $(TEST_MODULE)"
 	@$(MAKE) run BUILD_FLAVOR=$(TEST_BUILD_FLAVOR) HO_DEMO_TEST_NAME=$(TEST_MODULE) HO_DEMO_TEST_DEFINE=$(TEST_DEFINE_$(TEST_MODULE))
 endif
 
-schedule list:
+schedule user_hello list:
 	@:
 		
 debug: copy

--- a/src/arch/amd64/idt.c
+++ b/src/arch/amd64/idt.c
@@ -3,6 +3,7 @@
 #include "kernel/hodbg.h"
 #include <kernel/init.h>
 #include <kernel/ke/irql.h>
+#include <kernel/ke/user_bootstrap.h>
 #include <libc/string.h>
 
 static IDT_ENTRY kInterruptDescriptorTable[256];
@@ -20,6 +21,7 @@ extern void *gIsrStubTable[];
 
 static uint8_t GetVectorGateType(uint8_t vectorNumber);
 static uint8_t GetVectorIstIndex(uint8_t vectorNumber);
+static BOOL IsSynchronousTrapVector(uint8_t vectorNumber);
 
 static inline HO_VIRTUAL_ADDRESS
 ReadCr2(void)
@@ -49,14 +51,14 @@ LoadIdt(IDT_PTR *pIdtPtr)
 }
 
 static void
-HandleExternalInterrupt(INTERRUPT_FRAME *frame)
+HandleRegisteredVector(INTERRUPT_FRAME *frame)
 {
     uint8_t vectorNumber = (uint8_t)frame->VectorNumber;
     IDT_IRQ_HANDLER_ENTRY *entry = &kInterruptHandlers[vectorNumber];
 
     if (entry->Handler == NULL)
     {
-        klog(KLOG_LEVEL_ERROR, "[IDT] Unhandled external interrupt vector=%u\n", vectorNumber);
+        klog(KLOG_LEVEL_ERROR, "[IDT] Unhandled registered vector=%u\n", vectorNumber);
         return;
     }
 
@@ -68,6 +70,8 @@ GetVectorGateType(uint8_t vectorNumber)
 {
     switch (vectorNumber)
     {
+    case KE_USER_BOOTSTRAP_SYSCALL_VECTOR:
+        return IDT_FLAG_USER_TRAP_GATE;
     case 3: // #BP Breakpoint
     case 4: // #OF Overflow
         return IDT_FLAG_TRAP_GATE;
@@ -88,6 +92,12 @@ GetVectorIstIndex(uint8_t vectorNumber)
     default:
         return 0;
     }
+}
+
+static BOOL
+IsSynchronousTrapVector(uint8_t vectorNumber)
+{
+    return vectorNumber == KE_USER_BOOTSTRAP_SYSCALL_VECTOR;
 }
 
 void
@@ -127,8 +137,14 @@ IdtExceptionHandler(void *frame)
         return;
     }
 
+    if (IsSynchronousTrapVector(vectorNumber))
+    {
+        HandleRegisteredVector(dump);
+        return;
+    }
+
     KeEnterInterruptContext();
-    HandleExternalInterrupt(dump);
+    HandleRegisteredVector(dump);
     KeLeaveInterruptContext();
 }
 

--- a/src/arch/amd64/user_bootstrap.asm
+++ b/src/arch/amd64/user_bootstrap.asm
@@ -1,0 +1,60 @@
+;
+; HimuOperatingSystem
+;
+; File: arch/amd64/user_bootstrap.asm
+; Description:
+; Minimal first-entry helper that builds an iretq frame on the current kernel
+; stack and enters the staged bootstrap user context.
+;
+; Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+;
+
+bits 64
+default rel
+
+section .text
+
+; void KiUserBootstrapIretq(uint64_t userRip,
+;                           uint64_t userRsp,
+;                           uint64_t userRflags,
+;                           uint64_t userCs,
+;                           uint64_t userSs);
+;
+; System V AMD64 calling convention:
+;   rdi = userRip
+;   rsi = userRsp
+;   rdx = userRflags
+;   rcx = userCs
+;   r8  = userSs
+
+global KiUserBootstrapIretq
+KiUserBootstrapIretq:
+    mov ax, r8w
+    mov ds, ax
+    mov es, ax
+
+    push r8
+    push rsi
+    push rdx
+    push rcx
+    push rdi
+
+    cld
+
+    xor eax, eax
+    xor ebx, ebx
+    xor ecx, ecx
+    xor edx, edx
+    xor esi, esi
+    xor edi, edi
+    xor ebp, ebp
+    xor r8d, r8d
+    xor r9d, r9d
+    xor r10d, r10d
+    xor r11d, r11d
+    xor r12d, r12d
+    xor r13d, r13d
+    xor r14d, r14d
+    xor r15d, r15d
+
+    iretq

--- a/src/include/arch/amd64/idt.h
+++ b/src/include/arch/amd64/idt.h
@@ -13,6 +13,7 @@
 
 #define IDT_FLAG_INTERRUPT_GATE 0x8E // 64-bit Interrupt Gate (P=1, DPL=0, Type=E)
 #define IDT_FLAG_TRAP_GATE      0x8F // 64-bit Trap Gate (P=1, DPL=0, Type=F)
+#define IDT_FLAG_USER_TRAP_GATE 0xEF // 64-bit Trap Gate (P=1, DPL=3, Type=F)
 
 struct IDT_ENTRY
 {

--- a/src/include/kernel/ke/kthread.h
+++ b/src/include/kernel/ke/kthread.h
@@ -65,11 +65,14 @@ typedef struct KTHREAD_CONTEXT
     uint64_t RIP; // offset 56  (informational; actual RIP is on stack for KiSwitchContext)
 } KTHREAD_CONTEXT;
 
+struct KE_USER_BOOTSTRAP_STAGING;
+
 // ─────────────────────────────────────────────────────────────
 // KTHREAD structure
 // ─────────────────────────────────────────────────────────────
 
-#define KTHREAD_FLAG_IDLE (1U << 0)
+#define KTHREAD_FLAG_IDLE           (1U << 0)
+#define KTHREAD_FLAG_BOOTSTRAP_USER (1U << 1)
 
 typedef struct KTHREAD
 {
@@ -98,6 +101,7 @@ typedef struct KTHREAD
     KTHREAD_ENTRY EntryPoint;
     void *EntryArg;
     uint32_t Flags;
+    struct KE_USER_BOOTSTRAP_STAGING *UserBootstrapContext;
 } KTHREAD;
 
 // ─────────────────────────────────────────────────────────────

--- a/src/include/kernel/ke/mm.h
+++ b/src/include/kernel/ke/mm.h
@@ -58,6 +58,7 @@ typedef struct KE_PT_MAPPING
 {
     BOOL Present;
     BOOL LargeLeaf;
+    BOOL UserAccessible; // Every present entry in the resolved translation path carries PTE_USER.
     uint8_t Level; // 1 = 4KB PT leaf, 2 = 2MB PD leaf, 3 = 1GB PDPT leaf
     uint64_t PageSize;
     HO_PHYSICAL_ADDRESS PhysicalBase;
@@ -243,9 +244,10 @@ HO_KERNEL_API const KE_IMPORTED_REGION *KeFindImportedRegion(const KE_KERNEL_ADD
 /**
  * Query the imported root page table for a single 4KB virtual page.
  *
- * On success, @outMapping->Present reports whether the page is currently mapped. If a larger 2MB or 1GB imported leaf
- * covers the queried page, the query reports that large leaf without splitting it and returns the resolved backing
- * physical 4KB page in PhysicalBase.
+ * On success, @outMapping->Present reports whether the page is currently mapped. @outMapping->UserAccessible reports
+ * whether the full resolved translation path, including the leaf, currently carries PTE_USER and is therefore
+ * reachable from Ring3. If a larger 2MB or 1GB imported leaf covers the queried page, the query reports that large
+ * leaf without splitting it and returns the resolved backing physical 4KB page in PhysicalBase.
  */
 HO_KERNEL_API HO_NODISCARD HO_STATUS KePtQueryPage(const KE_KERNEL_ADDRESS_SPACE *space,
                                                    HO_VIRTUAL_ADDRESS virtAddr,

--- a/src/include/kernel/ke/user_bootstrap.h
+++ b/src/include/kernel/ke/user_bootstrap.h
@@ -1,0 +1,86 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/user_bootstrap.h
+ * Description: Minimal bootstrap-only user-mode ABI and log anchors.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <_hobase.h>
+#include <kernel/ke/kthread.h>
+
+/*
+ * The fixed low-half user window below is a staging/bootstrap model only.
+ * It reuses the shared imported kernel root for the first user-mode slice and
+ * must not be treated as the long-term per-process address-space contract.
+ * Keep it above the boot-time low 2GB identity import so hole validation sees
+ * an unmapped slot in the shared root.
+ */
+#define KE_USER_BOOTSTRAP_PAGE_SIZE              0x1000ULL
+#define KE_USER_BOOTSTRAP_WINDOW_BASE            0x0000000080000000ULL
+#define KE_USER_BOOTSTRAP_WINDOW_PAGE_COUNT      4ULL
+#define KE_USER_BOOTSTRAP_WINDOW_END_EXCLUSIVE   (KE_USER_BOOTSTRAP_WINDOW_BASE +                     \
+                                                  (KE_USER_BOOTSTRAP_WINDOW_PAGE_COUNT *              \
+                                                   KE_USER_BOOTSTRAP_PAGE_SIZE))
+#define KE_USER_BOOTSTRAP_CODE_BASE              KE_USER_BOOTSTRAP_WINDOW_BASE
+#define KE_USER_BOOTSTRAP_CONST_BASE             (KE_USER_BOOTSTRAP_CODE_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
+#define KE_USER_BOOTSTRAP_STACK_GUARD_BASE       (KE_USER_BOOTSTRAP_CONST_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
+#define KE_USER_BOOTSTRAP_STACK_BASE             (KE_USER_BOOTSTRAP_STACK_GUARD_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
+#define KE_USER_BOOTSTRAP_STACK_TOP              (KE_USER_BOOTSTRAP_STACK_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
+#define KE_USER_BOOTSTRAP_STACK_PAGE_COUNT       1ULL
+#define KE_USER_BOOTSTRAP_STACK_GUARD_PAGE_COUNT 1ULL
+
+/*
+ * Bootstrap raw syscall ABI:
+ * - Entry is a synchronous int 0x80 trap.
+ * - RAX carries the raw syscall number on entry and the return value on exit.
+ * - RDI, RSI, and RDX carry the first three bootstrap arguments.
+ *
+ * The SYS_RAW_* namespace is intentionally scoped to bring-up only. Future
+ * handle-oriented SYS_* services may use different numbers and semantics.
+ */
+#define KE_USER_BOOTSTRAP_SYSCALL_VECTOR             0x80U
+#define KE_USER_BOOTSTRAP_SYS_RAW_WRITE_MAX_LENGTH   256U
+
+#define SYS_RAW_INVALID                              0U
+#define SYS_RAW_WRITE                                1U
+#define SYS_RAW_EXIT                                 2U
+
+/*
+ * Stable user_hello evidence-chain anchors. Phase one only reserves these
+ * strings so later phases can reuse them without scattering magic strings.
+ */
+#define KE_USER_BOOTSTRAP_LOG_ENTER_USER_MODE          "[USERBOOT] enter user mode"
+#define KE_USER_BOOTSTRAP_LOG_HELLO                    "[USERBOOT] hello"
+#define KE_USER_BOOTSTRAP_LOG_SYS_RAW_EXIT             "[USERBOOT] SYS_RAW_EXIT"
+#define KE_USER_BOOTSTRAP_LOG_INVALID_SYSCALL          "[USERBOOT] invalid raw syscall"
+#define KE_USER_BOOTSTRAP_LOG_INVALID_USER_BUFFER      "[USERBOOT] invalid user buffer"
+#define KE_USER_BOOTSTRAP_LOG_TEARDOWN_FAILED          "[USERBOOT] bootstrap teardown failed"
+#define KE_USER_BOOTSTRAP_LOG_THREAD_TERMINATED_FORMAT "[SCHED] Thread %u terminated"
+#define KE_USER_BOOTSTRAP_LOG_IDLE_REAPER              "[USERBOOT] idle/reaper reclaimed user_hello thread"
+
+typedef struct KE_USER_BOOTSTRAP_STAGING KE_USER_BOOTSTRAP_STAGING;
+
+typedef struct KE_USER_BOOTSTRAP_CREATE_PARAMS
+{
+    const void *CodeBytes;
+    uint64_t CodeLength;
+    uint64_t EntryOffset;
+    const void *ConstBytes;
+    uint64_t ConstLength;
+} KE_USER_BOOTSTRAP_CREATE_PARAMS;
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapCreateStaging(
+    const KE_USER_BOOTSTRAP_CREATE_PARAMS *params,
+    KE_USER_BOOTSTRAP_STAGING **outStaging);
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapDestroyStaging(KE_USER_BOOTSTRAP_STAGING *staging);
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapAttachThread(KTHREAD *thread,
+                                                                 KE_USER_BOOTSTRAP_STAGING *staging);
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapRawSyscallInit(void);
+
+HO_KERNEL_API HO_NORETURN void KeUserBootstrapEnterCurrentThread(void);

--- a/src/kernel/demo/demo.c
+++ b/src/kernel/demo/demo.c
@@ -32,6 +32,12 @@ RunKernelDemos(void)
         return;
     }
 
+    if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_USER_HELLO)
+    {
+        RunUserHelloDemo();
+        return;
+    }
+
     if (HO_DEMO_TEST_SELECTION == HO_DEMO_TEST_THREAD)
     {
         RunThreadDemo();

--- a/src/kernel/demo/demo_internal.h
+++ b/src/kernel/demo/demo_internal.h
@@ -18,6 +18,7 @@
 #include <kernel/ke/event.h>
 #include <kernel/ke/mutex.h>
 #include <kernel/ke/semaphore.h>
+#include <kernel/ke/user_bootstrap.h>
 
 #define HO_DEMO_TEST_NONE              0
 #define HO_DEMO_TEST_SCHEDULE          1
@@ -36,6 +37,7 @@
 #define HO_DEMO_TEST_PF_FIXMAP         14
 #define HO_DEMO_TEST_PF_HEAP           15
 #define HO_DEMO_TEST_KTHREAD_POOL_RACE 16
+#define HO_DEMO_TEST_USER_HELLO        17
 
 #ifndef HO_DEMO_TEST_SELECTION
 #define HO_DEMO_TEST_SELECTION HO_DEMO_TEST_NONE
@@ -97,3 +99,4 @@ void RunPageFaultGuardDemo(void);
 void RunPageFaultFixmapDemo(void);
 void RunPageFaultHeapDemo(void);
 void RunKthreadPoolRaceDemo(void);
+void RunUserHelloDemo(void);

--- a/src/kernel/demo/user_hello.c
+++ b/src/kernel/demo/user_hello.c
@@ -1,0 +1,83 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: demo/user_hello.c
+ * Description: Minimal fixed-layout user_hello payload and profile wiring.
+ *
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#include "demo_internal.h"
+
+#define KI_U32_BYTE(value, shift) ((uint8_t)((((uint32_t)(value)) >> (shift)) & 0xFFU))
+#define KI_U32_LE_BYTES(value)    KI_U32_BYTE((value), 0), KI_U32_BYTE((value), 8), KI_U32_BYTE((value), 16), \
+                                 KI_U32_BYTE((value), 24)
+
+enum
+{
+    KI_USER_HELLO_PAYLOAD_ENTRY_OFFSET = 0U,
+    KI_USER_HELLO_PAYLOAD_HELLO_OFFSET = 0U,
+};
+
+static void KiUnexpectedUserHelloKernelEntry(void *arg);
+
+static const char gKiUserHelloConstBytes[] = KE_USER_BOOTSTRAP_LOG_HELLO "\n";
+
+enum
+{
+    KI_USER_HELLO_PAYLOAD_HELLO_LENGTH = sizeof(gKiUserHelloConstBytes) - 1U,
+};
+
+static const uint8_t gKiUserHelloCodeBytes[] = {
+    0xB8, KI_U32_LE_BYTES(SYS_RAW_WRITE),
+    0xBF, KI_U32_LE_BYTES((uint32_t)(KE_USER_BOOTSTRAP_CONST_BASE + KI_USER_HELLO_PAYLOAD_HELLO_OFFSET)),
+    0xBE, KI_U32_LE_BYTES(KI_USER_HELLO_PAYLOAD_HELLO_LENGTH),
+    0x31, 0xD2,
+    0xCD, KE_USER_BOOTSTRAP_SYSCALL_VECTOR,
+    0xB8, KI_U32_LE_BYTES(SYS_RAW_EXIT),
+    0x31, 0xFF,
+    0xCD, KE_USER_BOOTSTRAP_SYSCALL_VECTOR,
+    0x0F, 0x0B,
+};
+
+static void
+KiUnexpectedUserHelloKernelEntry(void *arg)
+{
+    (void)arg;
+    HO_KPANIC(EC_INVALID_STATE, "user_hello bootstrap thread unexpectedly executed the kernel entry point");
+}
+
+void
+RunUserHelloDemo(void)
+{
+    KE_USER_BOOTSTRAP_CREATE_PARAMS createParams = {
+        .CodeBytes = gKiUserHelloCodeBytes,
+        .CodeLength = sizeof(gKiUserHelloCodeBytes),
+        .EntryOffset = KI_USER_HELLO_PAYLOAD_ENTRY_OFFSET,
+        .ConstBytes = gKiUserHelloConstBytes,
+        .ConstLength = KI_USER_HELLO_PAYLOAD_HELLO_LENGTH,
+    };
+    KE_USER_BOOTSTRAP_STAGING *staging = NULL;
+    KTHREAD *thread = NULL;
+
+    HO_STATUS status = KeUserBootstrapCreateStaging(&createParams, &staging);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create staged user_hello payload");
+
+    status = KeThreadCreate(&thread, KiUnexpectedUserHelloKernelEntry, NULL);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to create user_hello bootstrap thread");
+
+    thread->Flags |= KTHREAD_FLAG_BOOTSTRAP_USER;
+
+    status = KeUserBootstrapAttachThread(thread, staging);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to attach staged user_hello payload to bootstrap thread");
+
+    status = KeThreadStart(thread);
+    if (status != EC_SUCCESS)
+        HO_KPANIC(status, "Failed to start user_hello bootstrap thread");
+}
+
+#undef KI_U32_LE_BYTES
+#undef KI_U32_BYTE

--- a/src/kernel/init/init.c
+++ b/src/kernel/init/init.c
@@ -1,4 +1,5 @@
 #include "init_internal.h"
+#include <kernel/ke/user_bootstrap.h>
 #include <kernel/ke/sysinfo.h>
 
 //
@@ -697,6 +698,12 @@ InitKernel(MAYBE_UNUSED STAGING_BLOCK *block)
     if (initStatus != EC_SUCCESS)
     {
         HO_KPANIC(initStatus, "Scheduler observability self-test failed");
+    }
+
+    initStatus = KeUserBootstrapRawSyscallInit();
+    if (initStatus != EC_SUCCESS)
+    {
+        HO_KPANIC(initStatus, "Failed to initialize bootstrap raw syscall trap");
     }
 }
 

--- a/src/kernel/ke/mm/address_space.c
+++ b/src/kernel/ke/mm/address_space.c
@@ -40,6 +40,12 @@ typedef struct KE_NEW_TABLE
     HO_PHYSICAL_ADDRESS TablePhys;
 } KE_NEW_TABLE;
 
+typedef struct KE_ENTRY_FLAG_PROMOTION
+{
+    PAGE_TABLE_ENTRY *Entry;
+    uint64_t AddedFlags;
+} KE_ENTRY_FLAG_PROMOTION;
+
 static KE_KERNEL_ADDRESS_SPACE gKernelAddressSpace;
 
 static inline HO_PHYSICAL_ADDRESS
@@ -60,6 +66,44 @@ static inline PAGE_TABLE_ENTRY *
 KiTableFromPhys(HO_PHYSICAL_ADDRESS physAddr)
 {
     return (PAGE_TABLE_ENTRY *)(uint64_t)HHDM_PHYS2VIRT(physAddr);
+}
+
+static inline uint64_t
+KiIntermediateEntryFlagsForLeaf(uint64_t leafAttributes)
+{
+    uint64_t flags = PTE_PRESENT | PTE_WRITABLE;
+
+    if ((leafAttributes & PTE_USER) != 0)
+        flags |= PTE_USER;
+
+    return flags;
+}
+
+static inline BOOL
+KiIsUserReachableEntry(const PAGE_TABLE_ENTRY *entry)
+{
+    return entry != NULL && ((*entry & (PTE_PRESENT | PTE_USER)) == (PTE_PRESENT | PTE_USER));
+}
+
+static BOOL
+KiIsWalkUserAccessible(const KE_PT_WALK *walk)
+{
+    if (!walk || !walk->LeafEntry)
+        return FALSE;
+
+    if (!KiIsUserReachableEntry(walk->Pml4Entry) || !KiIsUserReachableEntry(walk->PdptEntry))
+        return FALSE;
+
+    if (walk->Level == 3)
+        return TRUE;
+
+    if (!KiIsUserReachableEntry(walk->PdEntry))
+        return FALSE;
+
+    if (walk->Level == 2)
+        return TRUE;
+
+    return KiIsUserReachableEntry(walk->PtEntry);
 }
 
 static inline BOOL
@@ -119,13 +163,36 @@ KiRollbackNewTables(KE_NEW_TABLE *tables, uint32_t tableCount)
     }
 }
 
+static void
+KiRollbackEntryPromotions(KE_ENTRY_FLAG_PROMOTION *promotions, uint32_t promotionCount)
+{
+    while (promotionCount > 0)
+    {
+        --promotionCount;
+        *promotions[promotionCount].Entry &= ~promotions[promotionCount].AddedFlags;
+    }
+}
+
+static void
+KiRollbackMapSetup(KE_NEW_TABLE *tables,
+                   uint32_t tableCount,
+                   KE_ENTRY_FLAG_PROMOTION *promotions,
+                   uint32_t promotionCount)
+{
+    KiRollbackNewTables(tables, tableCount);
+    KiRollbackEntryPromotions(promotions, promotionCount);
+}
+
 static HO_STATUS
 KiEnsureChildTable(PAGE_TABLE_ENTRY *parentEntry,
+                   uint64_t leafAttributes,
                    KE_NEW_TABLE *newTables,
                    uint32_t *newTableCount,
+                   KE_ENTRY_FLAG_PROMOTION *promotions,
+                   uint32_t *promotionCount,
                    PAGE_TABLE_ENTRY **outTable)
 {
-    if (!parentEntry || !newTableCount || !outTable)
+    if (!parentEntry || !newTableCount || !promotions || !promotionCount || !outTable)
         return EC_ILLEGAL_ARGUMENT;
 
     if ((*parentEntry & PTE_PRESENT) == 0)
@@ -138,7 +205,7 @@ KiEnsureChildTable(PAGE_TABLE_ENTRY *parentEntry,
         PAGE_TABLE_ENTRY *table = KiTableFromPhys(tablePhys);
         memset(table, 0, PAGE_4KB);
 
-        *parentEntry = tablePhys | PTE_PRESENT | PTE_WRITABLE;
+        *parentEntry = tablePhys | KiIntermediateEntryFlagsForLeaf(leafAttributes);
         newTables[*newTableCount].ParentEntry = parentEntry;
         newTables[*newTableCount].TablePhys = tablePhys;
         ++(*newTableCount);
@@ -148,6 +215,17 @@ KiEnsureChildTable(PAGE_TABLE_ENTRY *parentEntry,
 
     if ((*parentEntry & PTE_PAGE_SIZE) != 0)
         return EC_NOT_SUPPORTED;
+
+    if ((leafAttributes & PTE_USER) != 0 && (*parentEntry & PTE_USER) == 0)
+    {
+        if (*promotionCount >= 3)
+            return EC_INVALID_STATE;
+
+        *parentEntry |= PTE_USER;
+        promotions[*promotionCount].Entry = parentEntry;
+        promotions[*promotionCount].AddedFlags = PTE_USER;
+        ++(*promotionCount);
+    }
 
     *outTable = KiTableFromPhys(*parentEntry & PAGE_MASK);
     return EC_SUCCESS;
@@ -421,6 +499,7 @@ KePtQueryPage(const KE_KERNEL_ADDRESS_SPACE *space, HO_VIRTUAL_ADDRESS virtAddr,
     outMapping->PageSize = walk.PageSize;
     outMapping->PhysicalBase = walk.LeafPhysBase;
     outMapping->Attributes = walk.LeafValue;
+    outMapping->UserAccessible = KiIsWalkUserAccessible(&walk);
     return EC_SUCCESS;
 }
 
@@ -475,38 +554,43 @@ KePtMapPage(const KE_KERNEL_ADDRESS_SPACE *space,
 
     KE_NEW_TABLE newTables[3];
     uint32_t newTableCount = 0;
+    KE_ENTRY_FLAG_PROMOTION promotions[3];
+    uint32_t promotionCount = 0;
     memset(newTables, 0, sizeof(newTables));
+    memset(promotions, 0, sizeof(promotions));
 
     PAGE_TABLE_ENTRY *pml4 = KiTableFromPhys(space->RootPageTablePhys);
     PAGE_TABLE_ENTRY *pml4Entry = &pml4[PML4_INDEX(virtAddr)];
     PAGE_TABLE_ENTRY *pdpt = NULL;
 
-    HO_STATUS status = KiEnsureChildTable(pml4Entry, newTables, &newTableCount, &pdpt);
+    HO_STATUS status = KiEnsureChildTable(
+        pml4Entry, attributes, newTables, &newTableCount, promotions, &promotionCount, &pdpt);
     if (status != EC_SUCCESS)
         return status;
 
     PAGE_TABLE_ENTRY *pdptEntry = &pdpt[PDPT_INDEX(virtAddr)];
     PAGE_TABLE_ENTRY *pd = NULL;
-    status = KiEnsureChildTable(pdptEntry, newTables, &newTableCount, &pd);
+    status = KiEnsureChildTable(
+        pdptEntry, attributes, newTables, &newTableCount, promotions, &promotionCount, &pd);
     if (status != EC_SUCCESS)
     {
-        KiRollbackNewTables(newTables, newTableCount);
+        KiRollbackMapSetup(newTables, newTableCount, promotions, promotionCount);
         return status;
     }
 
     PAGE_TABLE_ENTRY *pdEntry = &pd[PD_INDEX(virtAddr)];
     PAGE_TABLE_ENTRY *pt = NULL;
-    status = KiEnsureChildTable(pdEntry, newTables, &newTableCount, &pt);
+    status = KiEnsureChildTable(pdEntry, attributes, newTables, &newTableCount, promotions, &promotionCount, &pt);
     if (status != EC_SUCCESS)
     {
-        KiRollbackNewTables(newTables, newTableCount);
+        KiRollbackMapSetup(newTables, newTableCount, promotions, promotionCount);
         return status;
     }
 
     PAGE_TABLE_ENTRY *ptEntry = &pt[PT_INDEX(virtAddr)];
     if ((*ptEntry & PTE_PRESENT) != 0)
     {
-        KiRollbackNewTables(newTables, newTableCount);
+        KiRollbackMapSetup(newTables, newTableCount, promotions, promotionCount);
         return EC_INVALID_STATE;
     }
 

--- a/src/kernel/ke/thread/kthread.c
+++ b/src/kernel/ke/thread/kthread.c
@@ -130,6 +130,7 @@ KiThreadCreateInternal(KTHREAD **outThread,
     thread->EntryPoint = entryPoint;
     thread->EntryArg = arg;
     thread->Flags = 0;
+    thread->UserBootstrapContext = NULL;
 
     *outThread = thread;
 

--- a/src/kernel/ke/thread/scheduler/scheduler.c
+++ b/src/kernel/ke/thread/scheduler/scheduler.c
@@ -9,6 +9,8 @@
 
 #include "scheduler_internal.h"
 
+#include <kernel/ke/user_bootstrap.h>
+
 // ─────────────────────────────────────────────────────────────
 // Globals
 // ─────────────────────────────────────────────────────────────
@@ -31,10 +33,16 @@ uint64_t gNextProgrammedDeadlineNs;
 void
 KiThreadTrampoline(void)
 {
+    KTHREAD *self = KeGetCurrentThread();
+
+    if (self->UserBootstrapContext != NULL)
+    {
+        KeUserBootstrapEnterCurrentThread();
+    }
+
     ARCH_INTERRUPT_STATE enabledState = {.MaskableInterruptEnabled = TRUE};
     ArchRestoreInterruptState(enabledState);
 
-    KTHREAD *self = KeGetCurrentThread();
     self->EntryPoint(self->EntryArg);
     KeThreadExit();
     __builtin_unreachable();
@@ -80,6 +88,7 @@ KeSchedulerInit(void)
     gIdleThread->EntryPoint = NULL;
     gIdleThread->EntryArg = NULL;
     gIdleThread->Flags = KTHREAD_FLAG_IDLE;
+    gIdleThread->UserBootstrapContext = NULL;
 
     gCurrentThread = gIdleThread;
     KeSetCurrentIrqlState(&gIdleThread->IrqlState);
@@ -286,6 +295,15 @@ KiFinalizeThread(KTHREAD *thread)
     HO_KASSERT(thread->State == KTHREAD_STATE_TERMINATED, EC_INVALID_STATE);
     HO_KASSERT(thread->TerminationClaimState == KTHREAD_TERMINATION_CLAIM_STATE_CONSUMED, EC_INVALID_STATE);
 
+    if (thread->UserBootstrapContext != NULL)
+    {
+        HO_STATUS stagingStatus = KeUserBootstrapDestroyStaging(thread->UserBootstrapContext);
+        if (stagingStatus != EC_SUCCESS)
+        {
+            HO_KPANIC(stagingStatus, "Failed to release terminated KTHREAD user bootstrap staging");
+        }
+    }
+
     if (thread->StackOwnedByKva)
     {
         HO_STATUS status = KeKvaReleaseRangeHandle(&thread->StackRange);
@@ -319,7 +337,7 @@ KeThreadExit(void)
     thread->State = KTHREAD_STATE_TERMINATED;
     gStats.ActiveThreadCount--;
 
-    klog(KLOG_LEVEL_INFO, "[SCHED] Thread %u terminated\n", thread->ThreadId);
+    klog(KLOG_LEVEL_INFO, KE_USER_BOOTSTRAP_LOG_THREAD_TERMINATED_FORMAT "\n", thread->ThreadId);
 
     KeLeaveCriticalSection(&criticalSection);
 
@@ -585,6 +603,11 @@ KiReapTerminatedThreads(void)
         KeLeaveCriticalSection(&criticalSection);
         if (!thread)
             return;
+
+        if ((thread->Flags & KTHREAD_FLAG_BOOTSTRAP_USER) != 0)
+        {
+            klog(KLOG_LEVEL_INFO, KE_USER_BOOTSTRAP_LOG_IDLE_REAPER " thread=%u\n", thread->ThreadId);
+        }
 
         KiFinalizeThread(thread);
     }

--- a/src/kernel/ke/user_bootstrap.c
+++ b/src/kernel/ke/user_bootstrap.c
@@ -1,0 +1,399 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/user_bootstrap.c
+ * Description: Minimal staged user-mode bootstrap mapping and first-entry helpers.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#include <arch/amd64/pm.h>
+#include <kernel/ke/mm.h>
+#include <kernel/ke/scheduler.h>
+#include <kernel/ke/user_bootstrap.h>
+#include <kernel/hodbg.h>
+#include <libc/string.h>
+
+#define KE_USER_BOOTSTRAP_MAX_MAPPINGS 3U
+#define KE_USER_BOOTSTRAP_INITIAL_RFLAGS 0x202ULL
+
+typedef enum KE_USER_BOOTSTRAP_MAPPING_KIND
+{
+    KE_USER_BOOTSTRAP_MAPPING_KIND_CODE = 0,
+    KE_USER_BOOTSTRAP_MAPPING_KIND_CONST,
+    KE_USER_BOOTSTRAP_MAPPING_KIND_STACK,
+} KE_USER_BOOTSTRAP_MAPPING_KIND;
+
+typedef struct KE_USER_BOOTSTRAP_MAPPING_RECORD
+{
+    KE_USER_BOOTSTRAP_MAPPING_KIND Kind;
+    HO_VIRTUAL_ADDRESS VirtualBase;
+    HO_PHYSICAL_ADDRESS PhysicalBase;
+    uint64_t Attributes;
+} KE_USER_BOOTSTRAP_MAPPING_RECORD;
+
+struct KE_USER_BOOTSTRAP_STAGING
+{
+    HO_VIRTUAL_ADDRESS EntryPoint;
+    HO_VIRTUAL_ADDRESS StackBase;
+    HO_VIRTUAL_ADDRESS StackTop;
+    HO_VIRTUAL_ADDRESS GuardBase;
+    uint32_t MappingCount;
+    KTHREAD *AttachedThread;
+    KE_USER_BOOTSTRAP_MAPPING_RECORD Mappings[KE_USER_BOOTSTRAP_MAX_MAPPINGS];
+};
+
+extern HO_NORETURN void KiUserBootstrapIretq(HO_VIRTUAL_ADDRESS userRip,
+                                             HO_VIRTUAL_ADDRESS userRsp,
+                                             uint64_t userRflags,
+                                             uint64_t userCs,
+                                             uint64_t userSs);
+
+static HO_STATUS KiValidateCreateParams(const KE_USER_BOOTSTRAP_CREATE_PARAMS *params);
+static HO_STATUS KiValidateBootstrapHole(const KE_KERNEL_ADDRESS_SPACE *space, HO_VIRTUAL_ADDRESS virtAddr);
+static HO_STATUS KiPopulatePhysicalPage(HO_PHYSICAL_ADDRESS physAddr, const void *bytes, uint64_t byteCount);
+static HO_STATUS KiRecordMappedPage(KE_USER_BOOTSTRAP_STAGING *staging,
+                                    KE_USER_BOOTSTRAP_MAPPING_KIND kind,
+                                    HO_VIRTUAL_ADDRESS virtAddr,
+                                    HO_PHYSICAL_ADDRESS physAddr,
+                                    uint64_t attributes);
+static HO_STATUS KiAllocateAndMapUserPage(const KE_KERNEL_ADDRESS_SPACE *space,
+                                          KE_USER_BOOTSTRAP_STAGING *staging,
+                                          KE_USER_BOOTSTRAP_MAPPING_KIND kind,
+                                          HO_VIRTUAL_ADDRESS virtAddr,
+                                          uint64_t attributes,
+                                          const void *bytes,
+                                          uint64_t byteCount);
+static const KE_USER_BOOTSTRAP_MAPPING_RECORD *KiFindMappedPage(const KE_USER_BOOTSTRAP_STAGING *staging,
+                                                                KE_USER_BOOTSTRAP_MAPPING_KIND kind);
+
+static HO_STATUS
+KiValidateCreateParams(const KE_USER_BOOTSTRAP_CREATE_PARAMS *params)
+{
+    if (!params)
+        return EC_ILLEGAL_ARGUMENT;
+    if (!params->CodeBytes || params->CodeLength == 0 || params->CodeLength > KE_USER_BOOTSTRAP_PAGE_SIZE)
+        return EC_ILLEGAL_ARGUMENT;
+    if (params->EntryOffset >= params->CodeLength)
+        return EC_ILLEGAL_ARGUMENT;
+    if ((params->ConstBytes == NULL) != (params->ConstLength == 0))
+        return EC_ILLEGAL_ARGUMENT;
+    if (params->ConstLength > KE_USER_BOOTSTRAP_PAGE_SIZE)
+        return EC_ILLEGAL_ARGUMENT;
+
+    return EC_SUCCESS;
+}
+
+static HO_STATUS
+KiValidateBootstrapHole(const KE_KERNEL_ADDRESS_SPACE *space, HO_VIRTUAL_ADDRESS virtAddr)
+{
+    if (!space)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (KeFindImportedRegion(space, virtAddr) != NULL)
+        return EC_INVALID_STATE;
+
+    KE_PT_MAPPING mapping;
+    HO_STATUS status = KePtQueryPage(space, virtAddr, &mapping);
+    if (status != EC_SUCCESS)
+        return status;
+
+    return mapping.Present ? EC_INVALID_STATE : EC_SUCCESS;
+}
+
+static HO_STATUS
+KiPopulatePhysicalPage(HO_PHYSICAL_ADDRESS physAddr, const void *bytes, uint64_t byteCount)
+{
+    KE_TEMP_PHYS_MAP_HANDLE handle = {0};
+    HO_VIRTUAL_ADDRESS tempVirt = 0;
+    HO_STATUS status = KeTempPhysMapAcquire(physAddr, PTE_WRITABLE | PTE_NO_EXECUTE, &handle, &tempVirt);
+    if (status != EC_SUCCESS)
+        return status;
+
+    void *tempBuffer = (void *)(uint64_t)tempVirt;
+    memset(tempBuffer, 0, KE_USER_BOOTSTRAP_PAGE_SIZE);
+    if (bytes && byteCount != 0)
+    {
+        memcpy(tempBuffer, bytes, (size_t)byteCount);
+    }
+
+    HO_STATUS releaseStatus = KeTempPhysMapRelease(&handle);
+    if (releaseStatus != EC_SUCCESS)
+        return releaseStatus;
+
+    return EC_SUCCESS;
+}
+
+static HO_STATUS
+KiRecordMappedPage(KE_USER_BOOTSTRAP_STAGING *staging,
+                   KE_USER_BOOTSTRAP_MAPPING_KIND kind,
+                   HO_VIRTUAL_ADDRESS virtAddr,
+                   HO_PHYSICAL_ADDRESS physAddr,
+                   uint64_t attributes)
+{
+    if (!staging)
+        return EC_ILLEGAL_ARGUMENT;
+    if (staging->MappingCount >= KE_USER_BOOTSTRAP_MAX_MAPPINGS)
+        return EC_INVALID_STATE;
+
+    KE_USER_BOOTSTRAP_MAPPING_RECORD *record = &staging->Mappings[staging->MappingCount++];
+    record->Kind = kind;
+    record->VirtualBase = virtAddr;
+    record->PhysicalBase = physAddr;
+    record->Attributes = attributes;
+    return EC_SUCCESS;
+}
+
+static HO_STATUS
+KiAllocateAndMapUserPage(const KE_KERNEL_ADDRESS_SPACE *space,
+                        KE_USER_BOOTSTRAP_STAGING *staging,
+                        KE_USER_BOOTSTRAP_MAPPING_KIND kind,
+                        HO_VIRTUAL_ADDRESS virtAddr,
+                        uint64_t attributes,
+                        const void *bytes,
+                        uint64_t byteCount)
+{
+    HO_PHYSICAL_ADDRESS physAddr = 0;
+    HO_STATUS status = KePmmAllocPages(1, NULL, &physAddr);
+    if (status != EC_SUCCESS)
+        return status;
+
+    status = KiPopulatePhysicalPage(physAddr, bytes, byteCount);
+    if (status != EC_SUCCESS)
+    {
+        (void)KePmmFreePages(physAddr, 1);
+        return status;
+    }
+
+    status = KePtMapPage(space, virtAddr, physAddr, attributes);
+    if (status != EC_SUCCESS)
+    {
+        (void)KePmmFreePages(physAddr, 1);
+        return status;
+    }
+
+    status = KiRecordMappedPage(staging, kind, virtAddr, physAddr, attributes);
+    if (status != EC_SUCCESS)
+    {
+        HO_STATUS cleanupStatus = KePtUnmapPage(space, virtAddr);
+        if (cleanupStatus != EC_SUCCESS && cleanupStatus != EC_INVALID_STATE)
+        {
+            return cleanupStatus;
+        }
+        (void)KePmmFreePages(physAddr, 1);
+        return status;
+    }
+
+    return EC_SUCCESS;
+}
+
+static const KE_USER_BOOTSTRAP_MAPPING_RECORD *
+KiFindMappedPage(const KE_USER_BOOTSTRAP_STAGING *staging, KE_USER_BOOTSTRAP_MAPPING_KIND kind)
+{
+    if (!staging)
+        return NULL;
+
+    for (uint32_t index = 0; index < staging->MappingCount; ++index)
+    {
+        const KE_USER_BOOTSTRAP_MAPPING_RECORD *record = &staging->Mappings[index];
+        if (record->Kind == kind)
+            return record;
+    }
+
+    return NULL;
+}
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS
+KeUserBootstrapCreateStaging(const KE_USER_BOOTSTRAP_CREATE_PARAMS *params,
+                             KE_USER_BOOTSTRAP_STAGING **outStaging)
+{
+    HO_STATUS destroyStatus = EC_SUCCESS;
+
+    if (!outStaging)
+        return EC_ILLEGAL_ARGUMENT;
+
+    *outStaging = NULL;
+
+    HO_STATUS status = KiValidateCreateParams(params);
+    if (status != EC_SUCCESS)
+        return status;
+
+    const KE_KERNEL_ADDRESS_SPACE *space = KeGetKernelAddressSpace();
+    if (!space || !space->Initialized)
+        return EC_INVALID_STATE;
+
+    status = KiValidateBootstrapHole(space, 0);
+    if (status != EC_SUCCESS)
+        return status;
+
+    status = KiValidateBootstrapHole(space, KE_USER_BOOTSTRAP_CODE_BASE);
+    if (status != EC_SUCCESS)
+        return status;
+
+    status = KiValidateBootstrapHole(space, KE_USER_BOOTSTRAP_CONST_BASE);
+    if (status != EC_SUCCESS)
+        return status;
+
+    status = KiValidateBootstrapHole(space, KE_USER_BOOTSTRAP_STACK_GUARD_BASE);
+    if (status != EC_SUCCESS)
+        return status;
+
+    status = KiValidateBootstrapHole(space, KE_USER_BOOTSTRAP_STACK_BASE);
+    if (status != EC_SUCCESS)
+        return status;
+
+    KE_USER_BOOTSTRAP_STAGING *staging = (KE_USER_BOOTSTRAP_STAGING *)kzalloc(sizeof(*staging));
+    if (!staging)
+        return EC_OUT_OF_RESOURCE;
+
+    staging->EntryPoint = KE_USER_BOOTSTRAP_CODE_BASE + params->EntryOffset;
+    staging->StackBase = KE_USER_BOOTSTRAP_STACK_BASE;
+    staging->StackTop = KE_USER_BOOTSTRAP_STACK_TOP;
+    staging->GuardBase = KE_USER_BOOTSTRAP_STACK_GUARD_BASE;
+
+    status = KiAllocateAndMapUserPage(space,
+                                      staging,
+                                      KE_USER_BOOTSTRAP_MAPPING_KIND_CODE,
+                                      KE_USER_BOOTSTRAP_CODE_BASE,
+                                      PTE_USER,
+                                      params->CodeBytes,
+                                      params->CodeLength);
+    if (status != EC_SUCCESS)
+        goto cleanup;
+
+    if (params->ConstLength != 0)
+    {
+        status = KiAllocateAndMapUserPage(space,
+                                          staging,
+                                          KE_USER_BOOTSTRAP_MAPPING_KIND_CONST,
+                                          KE_USER_BOOTSTRAP_CONST_BASE,
+                                          PTE_USER | PTE_NO_EXECUTE,
+                                          params->ConstBytes,
+                                          params->ConstLength);
+        if (status != EC_SUCCESS)
+            goto cleanup;
+    }
+
+    status = KiAllocateAndMapUserPage(space,
+                                      staging,
+                                      KE_USER_BOOTSTRAP_MAPPING_KIND_STACK,
+                                      KE_USER_BOOTSTRAP_STACK_BASE,
+                                      PTE_USER | PTE_WRITABLE | PTE_NO_EXECUTE,
+                                      NULL,
+                                      0);
+    if (status != EC_SUCCESS)
+        goto cleanup;
+
+    status = KiValidateBootstrapHole(space, staging->GuardBase);
+    if (status != EC_SUCCESS)
+        goto cleanup;
+
+    *outStaging = staging;
+    return EC_SUCCESS;
+
+cleanup:
+    destroyStatus = KeUserBootstrapDestroyStaging(staging);
+    if (destroyStatus != EC_SUCCESS)
+        return destroyStatus;
+    return status;
+}
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS
+KeUserBootstrapDestroyStaging(KE_USER_BOOTSTRAP_STAGING *staging)
+{
+    if (!staging)
+        return EC_ILLEGAL_ARGUMENT;
+
+    HO_STATUS firstError = EC_SUCCESS;
+    const KE_KERNEL_ADDRESS_SPACE *space = KeGetKernelAddressSpace();
+
+    if (staging->AttachedThread != NULL)
+    {
+        HO_KASSERT(staging->AttachedThread->UserBootstrapContext == staging, EC_INVALID_STATE);
+        staging->AttachedThread->UserBootstrapContext = NULL;
+        staging->AttachedThread = NULL;
+    }
+
+    while (staging->MappingCount != 0)
+    {
+        KE_USER_BOOTSTRAP_MAPPING_RECORD *record = &staging->Mappings[staging->MappingCount - 1];
+        BOOL canFreeBackingPage = FALSE;
+
+        if (space && space->Initialized)
+        {
+            HO_STATUS unmapStatus = KePtUnmapPage(space, record->VirtualBase);
+            if (unmapStatus == EC_SUCCESS || unmapStatus == EC_INVALID_STATE)
+            {
+                canFreeBackingPage = TRUE;
+            }
+            else if (firstError == EC_SUCCESS)
+            {
+                firstError = unmapStatus;
+            }
+        }
+        else if (firstError == EC_SUCCESS)
+        {
+            firstError = EC_INVALID_STATE;
+        }
+
+        if (canFreeBackingPage)
+        {
+            HO_STATUS freeStatus = KePmmFreePages(record->PhysicalBase, 1);
+            if (freeStatus != EC_SUCCESS && firstError == EC_SUCCESS)
+            {
+                firstError = freeStatus;
+            }
+        }
+
+        memset(record, 0, sizeof(*record));
+        --staging->MappingCount;
+    }
+
+    kfree(staging);
+    return firstError;
+}
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS
+KeUserBootstrapAttachThread(KTHREAD *thread, KE_USER_BOOTSTRAP_STAGING *staging)
+{
+    if (!thread || !staging)
+        return EC_ILLEGAL_ARGUMENT;
+    if ((thread->Flags & KTHREAD_FLAG_IDLE) != 0)
+        return EC_INVALID_STATE;
+    if (thread->State != KTHREAD_STATE_NEW)
+        return EC_INVALID_STATE;
+    if (thread->UserBootstrapContext != NULL && thread->UserBootstrapContext != staging)
+        return EC_INVALID_STATE;
+    if (staging->AttachedThread != NULL && staging->AttachedThread != thread)
+        return EC_INVALID_STATE;
+    if (KiFindMappedPage(staging, KE_USER_BOOTSTRAP_MAPPING_KIND_CODE) == NULL)
+        return EC_INVALID_STATE;
+    if (KiFindMappedPage(staging, KE_USER_BOOTSTRAP_MAPPING_KIND_STACK) == NULL)
+        return EC_INVALID_STATE;
+
+    staging->AttachedThread = thread;
+    thread->UserBootstrapContext = staging;
+    return EC_SUCCESS;
+}
+
+HO_KERNEL_API HO_NORETURN void
+KeUserBootstrapEnterCurrentThread(void)
+{
+    KTHREAD *thread = KeGetCurrentThread();
+    HO_KASSERT(thread != NULL, EC_INVALID_STATE);
+    HO_KASSERT(thread->UserBootstrapContext != NULL, EC_INVALID_STATE);
+
+    KE_USER_BOOTSTRAP_STAGING *staging = thread->UserBootstrapContext;
+    HO_KASSERT(staging->AttachedThread == thread, EC_INVALID_STATE);
+    HO_KASSERT(KiFindMappedPage(staging, KE_USER_BOOTSTRAP_MAPPING_KIND_CODE) != NULL, EC_INVALID_STATE);
+    HO_KASSERT(KiFindMappedPage(staging, KE_USER_BOOTSTRAP_MAPPING_KIND_STACK) != NULL, EC_INVALID_STATE);
+    HO_KASSERT(staging->EntryPoint >= KE_USER_BOOTSTRAP_CODE_BASE, EC_INVALID_STATE);
+    HO_KASSERT(staging->EntryPoint < (KE_USER_BOOTSTRAP_CODE_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE), EC_INVALID_STATE);
+    HO_KASSERT(staging->StackBase == KE_USER_BOOTSTRAP_STACK_BASE, EC_INVALID_STATE);
+    HO_KASSERT(staging->StackTop == KE_USER_BOOTSTRAP_STACK_TOP, EC_INVALID_STATE);
+
+    klog(KLOG_LEVEL_INFO, KE_USER_BOOTSTRAP_LOG_ENTER_USER_MODE "\n");
+
+    KiUserBootstrapIretq(
+        staging->EntryPoint, staging->StackTop, KE_USER_BOOTSTRAP_INITIAL_RFLAGS, GDT_USER_CODE_SEL, GDT_USER_DATA_SEL);
+    __builtin_unreachable();
+}

--- a/src/kernel/ke/user_bootstrap_syscall.c
+++ b/src/kernel/ke/user_bootstrap_syscall.c
@@ -1,0 +1,287 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/user_bootstrap_syscall.c
+ * Description: Minimal bootstrap raw syscall dispatcher and user-copy helpers.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#include <arch/amd64/idt.h>
+#include <arch/amd64/pm.h>
+#include <kernel/hodbg.h>
+#include <kernel/ke/console.h>
+#include <kernel/ke/mm.h>
+#include <kernel/ke/scheduler.h>
+#include <kernel/ke/user_bootstrap.h>
+#include <libc/string.h>
+
+static BOOL gKeUserBootstrapRawSyscallInitialized;
+
+static int64_t KiEncodeRawSyscallStatus(HO_STATUS status);
+static HO_NORETURN void KiAbortRawExit(KTHREAD *thread,
+                                       uint64_t exitCode,
+                                       HO_STATUS status,
+                                       const char *reason);
+static HO_STATUS KiValidateUserRange(HO_VIRTUAL_ADDRESS userBase,
+                                     uint64_t length,
+                                     HO_VIRTUAL_ADDRESS *outEndExclusive);
+static HO_STATUS KiValidateUserReadablePages(const KE_KERNEL_ADDRESS_SPACE *space,
+                                             HO_VIRTUAL_ADDRESS userBase,
+                                             HO_VIRTUAL_ADDRESS endExclusive);
+static HO_STATUS KiCopyInUserBytes(void *kernelDestination, HO_VIRTUAL_ADDRESS userSource, uint64_t length);
+static int64_t KiHandleRawWrite(uint64_t userBuffer, uint64_t length);
+static int64_t KiHandleRawExit(uint64_t exitCode);
+static int64_t KiDispatchRawSyscall(uint64_t rawSyscallNumber, uint64_t arg0, uint64_t arg1, uint64_t arg2);
+static void KiHandleRawSyscallTrap(void *frame, void *context);
+
+static int64_t
+KiEncodeRawSyscallStatus(HO_STATUS status)
+{
+    return status == EC_SUCCESS ? 0 : -(int64_t)status;
+}
+
+static HO_NORETURN void
+KiAbortRawExit(KTHREAD *thread, uint64_t exitCode, HO_STATUS status, const char *reason)
+{
+    klog(KLOG_LEVEL_ERROR,
+         KE_USER_BOOTSTRAP_LOG_TEARDOWN_FAILED " raw=exit unrecoverable thread=%u code=%lu reason=%s status=%s (%d)\n",
+         thread ? thread->ThreadId : 0U,
+         (unsigned long)exitCode,
+         reason,
+         KrGetStatusMessage(status),
+         status);
+    HO_KPANIC(status, reason);
+}
+
+static HO_STATUS
+KiValidateUserRange(HO_VIRTUAL_ADDRESS userBase, uint64_t length, HO_VIRTUAL_ADDRESS *outEndExclusive)
+{
+    if (!outEndExclusive)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (length == 0)
+    {
+        *outEndExclusive = userBase;
+        return EC_SUCCESS;
+    }
+
+    if (userBase < KE_USER_BOOTSTRAP_WINDOW_BASE)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (userBase >= KE_USER_BOOTSTRAP_WINDOW_END_EXCLUSIVE)
+        return EC_ILLEGAL_ARGUMENT;
+
+    HO_VIRTUAL_ADDRESS endExclusive = userBase + length;
+    if (endExclusive < userBase)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (endExclusive > KE_USER_BOOTSTRAP_WINDOW_END_EXCLUSIVE)
+        return EC_ILLEGAL_ARGUMENT;
+
+    *outEndExclusive = endExclusive;
+    return EC_SUCCESS;
+}
+
+static HO_STATUS
+KiValidateUserReadablePages(const KE_KERNEL_ADDRESS_SPACE *space,
+                            HO_VIRTUAL_ADDRESS userBase,
+                            HO_VIRTUAL_ADDRESS endExclusive)
+{
+    if (!space || !space->Initialized)
+        return EC_INVALID_STATE;
+
+    if (userBase == endExclusive)
+        return EC_SUCCESS;
+
+    HO_VIRTUAL_ADDRESS pageBase = HO_ALIGN_DOWN(userBase, PAGE_4KB);
+    HO_VIRTUAL_ADDRESS lastPageBase = HO_ALIGN_DOWN(endExclusive - 1, PAGE_4KB);
+
+    for (;;)
+    {
+        KE_PT_MAPPING mapping = {0};
+        HO_STATUS status = KePtQueryPage(space, pageBase, &mapping);
+        if (status != EC_SUCCESS)
+        {
+            klog(KLOG_LEVEL_WARNING,
+                 KE_USER_BOOTSTRAP_LOG_INVALID_USER_BUFFER " query failed addr=%p status=%s (%d)\n",
+                 (void *)(uint64_t)pageBase,
+                 KrGetStatusMessage(status),
+                 status);
+            return status;
+        }
+
+        if (!mapping.Present || !mapping.UserAccessible)
+        {
+            klog(KLOG_LEVEL_WARNING,
+                 KE_USER_BOOTSTRAP_LOG_INVALID_USER_BUFFER " addr=%p present=%u userReachable=%u attrs=%p\n",
+                 (void *)(uint64_t)pageBase,
+                 mapping.Present,
+                 mapping.UserAccessible,
+                 (void *)(uint64_t)mapping.Attributes);
+            return EC_ILLEGAL_ARGUMENT;
+        }
+
+        if (pageBase == lastPageBase)
+            break;
+
+        pageBase += PAGE_4KB;
+    }
+
+    return EC_SUCCESS;
+}
+
+static HO_STATUS
+KiCopyInUserBytes(void *kernelDestination, HO_VIRTUAL_ADDRESS userSource, uint64_t length)
+{
+    if (!kernelDestination)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (length == 0)
+        return EC_SUCCESS;
+
+    HO_VIRTUAL_ADDRESS endExclusive = 0;
+    HO_STATUS status = KiValidateUserRange(userSource, length, &endExclusive);
+    if (status != EC_SUCCESS)
+    {
+        klog(KLOG_LEVEL_WARNING,
+             KE_USER_BOOTSTRAP_LOG_INVALID_USER_BUFFER " range addr=%p len=%lu status=%s (%d)\n",
+             (void *)(uint64_t)userSource,
+             (unsigned long)length,
+             KrGetStatusMessage(status),
+             status);
+        return status;
+    }
+
+    const KE_KERNEL_ADDRESS_SPACE *space = KeGetKernelAddressSpace();
+    status = KiValidateUserReadablePages(space, userSource, endExclusive);
+    if (status != EC_SUCCESS)
+        return status;
+
+    memcpy(kernelDestination, (const void *)(uint64_t)userSource, (size_t)length);
+    return EC_SUCCESS;
+}
+
+static int64_t
+KiHandleRawWrite(uint64_t userBuffer, uint64_t length)
+{
+    if (length > KE_USER_BOOTSTRAP_SYS_RAW_WRITE_MAX_LENGTH)
+    {
+        klog(KLOG_LEVEL_WARNING,
+             KE_USER_BOOTSTRAP_LOG_INVALID_USER_BUFFER " raw=write addr=%p len=%lu exceeds=%u\n",
+             (void *)(uint64_t)userBuffer,
+             (unsigned long)length,
+             KE_USER_BOOTSTRAP_SYS_RAW_WRITE_MAX_LENGTH);
+        return KiEncodeRawSyscallStatus(EC_ILLEGAL_ARGUMENT);
+    }
+
+    if (length == 0)
+        return 0;
+
+    char scratch[KE_USER_BOOTSTRAP_SYS_RAW_WRITE_MAX_LENGTH];
+    HO_STATUS status = KiCopyInUserBytes(scratch, (HO_VIRTUAL_ADDRESS)userBuffer, length);
+    if (status != EC_SUCCESS)
+        return KiEncodeRawSyscallStatus(status);
+
+    uint64_t written = 0;
+    for (uint64_t index = 0; index < length; ++index)
+    {
+        if (ConsoleWriteChar(scratch[index]) < 0)
+        {
+            klog(KLOG_LEVEL_ERROR,
+                 "[USERBOOT] SYS_RAW_WRITE console emit failed index=%lu thread=%u\n",
+                 (unsigned long)index,
+                 KeGetCurrentThread() ? KeGetCurrentThread()->ThreadId : 0U);
+            return KiEncodeRawSyscallStatus(EC_FAILURE);
+        }
+
+        ++written;
+    }
+
+    return (int64_t)written;
+}
+
+static int64_t
+KiHandleRawExit(uint64_t exitCode)
+{
+    KTHREAD *thread = KeGetCurrentThread();
+    if (!thread || thread->UserBootstrapContext == NULL)
+        KiAbortRawExit(thread, exitCode, EC_INVALID_STATE, "Bootstrap raw exit missing staging");
+
+    klog(KLOG_LEVEL_INFO,
+         KE_USER_BOOTSTRAP_LOG_SYS_RAW_EXIT " code=%lu thread=%u\n",
+         (unsigned long)exitCode,
+         thread->ThreadId);
+
+    HO_STATUS status = KeUserBootstrapDestroyStaging(thread->UserBootstrapContext);
+    if (status != EC_SUCCESS)
+        KiAbortRawExit(thread, exitCode, status, "Bootstrap raw exit teardown failed after no-return transition");
+
+    KeThreadExit();
+}
+
+static int64_t
+KiDispatchRawSyscall(uint64_t rawSyscallNumber, uint64_t arg0, uint64_t arg1, uint64_t arg2)
+{
+    KTHREAD *thread = KeGetCurrentThread();
+    if (!thread || thread->UserBootstrapContext == NULL)
+    {
+        if (rawSyscallNumber == SYS_RAW_EXIT)
+            KiAbortRawExit(thread, arg0, EC_INVALID_STATE, "Bootstrap raw exit missing staging");
+
+        klog(KLOG_LEVEL_ERROR,
+             KE_USER_BOOTSTRAP_LOG_INVALID_SYSCALL " nr=%lu thread=%u missing bootstrap staging\n",
+             (unsigned long)rawSyscallNumber,
+             thread ? thread->ThreadId : 0U);
+        return KiEncodeRawSyscallStatus(EC_INVALID_STATE);
+    }
+
+    switch (rawSyscallNumber)
+    {
+    case SYS_RAW_WRITE:
+        return KiHandleRawWrite(arg0, arg1);
+    case SYS_RAW_EXIT:
+        return KiHandleRawExit(arg0);
+    default:
+        klog(KLOG_LEVEL_WARNING,
+             KE_USER_BOOTSTRAP_LOG_INVALID_SYSCALL " nr=%lu thread=%u args=(%p,%p,%p)\n",
+             (unsigned long)rawSyscallNumber,
+             thread->ThreadId,
+             (void *)(uint64_t)arg0,
+             (void *)(uint64_t)arg1,
+             (void *)(uint64_t)arg2);
+        return KiEncodeRawSyscallStatus(EC_NOT_SUPPORTED);
+    }
+}
+
+static void
+KiHandleRawSyscallTrap(void *frame, MAYBE_UNUSED void *context)
+{
+    INTERRUPT_FRAME *interruptFrame = (INTERRUPT_FRAME *)frame;
+    int64_t returnValue = KiDispatchRawSyscall(interruptFrame->Context.RAX,
+                                               interruptFrame->Context.RDI,
+                                               interruptFrame->Context.RSI,
+                                               interruptFrame->Context.RDX);
+    interruptFrame->Context.RAX = (uint64_t)returnValue;
+}
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS
+KeUserBootstrapRawSyscallInit(void)
+{
+    if (gKeUserBootstrapRawSyscallInitialized)
+        return EC_SUCCESS;
+
+    HO_STATUS status = IdtRegisterInterruptHandler(KE_USER_BOOTSTRAP_SYSCALL_VECTOR, KiHandleRawSyscallTrap, NULL);
+    if (status != EC_SUCCESS)
+    {
+        klog(KLOG_LEVEL_ERROR,
+             "[USERBOOT] failed to register raw syscall vector=%u status=%s (%d)\n",
+             KE_USER_BOOTSTRAP_SYSCALL_VECTOR,
+             KrGetStatusMessage(status),
+             status);
+        return status;
+    }
+
+    gKeUserBootstrapRawSyscallInitialized = TRUE;
+    klog(KLOG_LEVEL_INFO, "[USERBOOT] raw syscall trap ready vector=%u\n", KE_USER_BOOTSTRAP_SYSCALL_VECTOR);
+    return EC_SUCCESS;
+}


### PR DESCRIPTION
## What changed
This PR adds the first minimal user-mode vertical slice behind the `user_hello` regression profile.

It introduces a bounded bootstrap path that:
- maps the minimal user code and stack pages into the shared imported root
- performs the first Ring 3 transition through a kernel-managed `iretq` bootstrap
- routes `int 0x80` into a thin raw-syscall trap path
- implements `SYS_RAW_WRITE` and `SYS_RAW_EXIT`
- returns cleanly to the existing terminated-thread and idle/reaper flow

## Why
We accidentally started this work on top of a branch whose earlier PR had already been merged into `main` on April 2, 2026. This branch was recreated from the latest `origin/main`, and only the new minimal user-mode work was cherry-picked over so the PR scope stays clean.

## Developer impact
The new validation profile is:
- `BUILD_FLAVOR=test-user_hello`
- `HO_DEMO_TEST_NAME=user_hello`
- `HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_USER_HELLO`

This keeps the user-mode bring-up as a narrow bootstrap slice instead of introducing a full process model.

## Validation
- `make clean`
- `bear -- make all BUILD_FLAVOR=test-user_hello HO_DEMO_TEST_NAME=user_hello HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_USER_HELLO`
- `BUILD_FLAVOR=test-user_hello HO_DEMO_TEST_NAME=user_hello HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_USER_HELLO QEMU_DISPLAY=none scripts/qemu_capture.sh 25 /tmp/qemu_user_hello.log`

The captured log showed the expected chain:
- `enter user mode`
- `hello`
- `SYS_RAW_EXIT`
- `Thread 1 terminated`
- `idle/reaper reclaimed user_hello thread`

## Notes
OpenSpec archive cleanup for `bootstrap-minimal-user-mode` was performed locally as requested. The repository currently ignores `openspec/`, so those artifacts are not part of the git diff for this PR.
