### PR TITLE
Introduce simple Ex bootstrap layer and cut over user bootstrap flow

### DIFF
--- a/agent-log.md
+++ b/agent-log.md
@@ -1,0 +1,55 @@
+# Agent Log: introduce-ex-bootstrap-adapter
+
+## 阶段计划
+
+agent 正在统筹 `introduce-ex-bootstrap-adapter` 的四阶段实施计划。
+
+### Phase 1: Contract & Scaffolding (tasks 1.1, 1.2)
+- 1.1: 在 `user_hello` 相关代码注释中固定 clean-pass 验收锚点，明确本 change 只允许边界重构
+- 1.2: 新建 `src/kernel/ex/` 和 `src/include/kernel/ex/` 目录结构，创建骨架头文件和源文件，更新 makefile
+
+### Phase 2: Thin Ex Ownership Layer (tasks 2.1, 2.2)
+- 2.1: 定义 `EX_PROCESS` / `EX_THREAD` 最小结构体与辅助接口
+- 2.2: 将 bootstrap staging 创建/关联/生命周期聚拢到 Ex 薄壳对象
+
+### Phase 3: Ke Callback Decoupling (tasks 3.1, 3.2, 3.3)
+- 3.1: 在 Ke 中引入 `KE_BOOTSTRAP_CALLBACKS` 注册合同（enter / finalize / timer_observe）
+- 3.2: scheduler.c 中硬编码 bootstrap 分支改为回调分发
+- 3.3: timer.c 中硬编码观察逻辑改为回调分发 + fail-fast
+
+### Phase 4: Validation & Documentation Sync (tasks 4.1, 4.2, 4.3)
+- 构建验证、运行 profile 验证 evidence chain、文档同步
+
+---
+
+## 实施记录
+
+### Phase 1 开始
+agent 正在启动 Phase 1: Contract & Scaffolding 实施。
+- impl 完成 1.1（anchor comment）、1.2（目录骨架 + makefile）
+- reviewer PASS
+- commit: `phase-1: contract anchor and Ex scaffold`
+
+### Phase 2 开始
+agent 正在启动 Phase 2: Thin Ex Ownership Layer 实施。
+- impl 完成 2.1（EX_PROCESS / EX_THREAD 结构定义）、2.2（staging 生命周期聚拢到 Ex）
+- reviewer 首次 BLOCK：FinalizeThread 在 staging destroy 失败时提前返回导致 Ex 对象泄漏
+- 修复：移除 early return，始终清理 Ex 对象，仅传播错误状态
+- reviewer 二次 PASS
+- commit: `phase-2: thin Ex ownership layer (EX_PROCESS / EX_THREAD)`
+
+### Phase 3 开始
+agent 正在启动 Phase 3: Ke Callback Decoupling 实施。
+- impl 完成 3.1（bootstrap_callbacks.h/c 注册合同）、3.2（scheduler 回调分发）、3.3（timer 回调分发）
+- scheduler.c / timer.c 不再 `#include <kernel/ke/user_bootstrap.h>`
+- Ex 注册三个回调实现，init.c 调用 ExBootstrapAdapterInit
+- reviewer PASS
+- commit: `phase-3: Ke callback decoupling (enter / finalize / timer_observe)`
+
+### Phase 4 开始
+agent 正在启动 Phase 4: Validation & Documentation Sync 实施。
+- 4.1: `make clean; bear -- make all BUILD_FLAVOR=test-user_hello ...` 构建成功
+- 4.2: `qemu_capture.sh` evidence chain 全部 10 个锚点验证通过
+- 4.3: 更新 `docs/current-ability.md` 反映 Ex 适配层与回调收口
+- 所有 tasks 完成
+

--- a/agent-log.md
+++ b/agent-log.md
@@ -53,3 +53,67 @@ agent 正在启动 Phase 4: Validation & Documentation Sync 实施。
 - 4.3: 更新 `docs/current-ability.md` 反映 Ex 适配层与回调收口
 - 所有 tasks 完成
 
+---
+
+# Agent Log: complete-ex-bootstrap-migration
+
+## 阶段计划
+
+agent 正在统筹 `complete-ex-bootstrap-migration` 的串行实施计划。
+
+### Phase 1: Ex Runtime And Launch API (tasks 1.1, 1.2)
+- 1.1: 新增 Ex-owned bootstrap runtime 初始化入口，收口 raw syscall trap 初始化与 bootstrap callback 注册
+- 1.2: 定义最小 Ex bootstrap create/start/teardown API 与参数类型，对外只暴露 Ex 头文件和 Ex 薄对象
+
+### Phase 2: Demo Launch Cutover (tasks 2.1, 2.2)
+- 2.1: 将 `user_hello` 迁移到 Ex create/start API 链路，移除手工 staging attach 与 bootstrap flag 设置
+- 2.2: 让 Ex 在 thread start 前建立 bootstrap ownership，使 trampoline 首次进入与 timer observe 可以走 Ex 查询面
+
+### Phase 3: Ke Residue Removal (tasks 3.1, 3.2, 3.3, 3.4)
+- 3.1: 扩展最小 bootstrap callback contract，引入 thread ownership query，并收口 finalizer/reaper 判定
+- 3.2: 将 `SYS_RAW_EXIT` clean-path teardown 改成 Ex-owned lifecycle helper，并保证 destroy 失败时仍清理 Ex wrapper / registry
+- 3.3: 删除 `KTHREAD_FLAG_BOOTSTRAP_USER` 与 `UserBootstrapContext`，收掉 scheduler、timer、demo、init 中的直接读取
+- 3.4: 通过 Ex-owned facade 隐藏 `user_bootstrap*` 的公开 surface；如无必要，不做物理迁移
+
+### Phase 4: Validation And Docs (tasks 4.1, 4.2, 4.3)
+- 4.1: 按 test-user_hello flavor 执行 clean rebuild
+- 4.2: 用 `scripts/qemu_capture.sh` 采集日志并核对 evidence chain 与 idle/reaper reclaim
+- 4.3: 同步更新能力与设计文档，说明 Ex 已成为 bootstrap launch/init/teardown owner
+
+## 实施记录
+
+### Phase 1 开始
+agent 正在启动 Phase 1: Ex Runtime And Launch API 实施。
+- 当前策略：先以最小改动新增 Ex facade 与 runtime init 收口，不提前删除 Ke 残留字段。
+- 当前检查结果：`user_hello` 仍直接创建 staging、设置 `KTHREAD_FLAG_BOOTSTRAP_USER` 并 attach 到 `KTHREAD`；`InitKernel()` 仍直接调用 `KeUserBootstrapRawSyscallInit()`。
+- reviewer 首轮 BLOCK：新公开的 Ex bootstrap 句柄在 start 后会被内核侧异步释放，post-start ownership contract 不安全；同时 `ExBootstrapTeardownThread()` 对已启动线程会过早销毁 staging。
+- 当前修复方向：收紧 public API ownership 语义，让 create/start 显式转移句柄所有权，并把 `ExBootstrapTeardownThread()` 限制为 pre-start cancel path。
+- impl 已完成 Phase 1：新增 `ExBootstrapInit()`、bootstrap-scoped Ex process/thread create/start/teardown facade、私有 Ex wrapper 共享状态，并将 `InitKernel()` 切换为单一 Ex 初始化入口。
+- reviewer 二次 PASS：确认 started-thread 不会再被 public teardown 提前销毁，public handle 的 ownership transfer contract 已收紧到安全边界。
+- 构建验证：`make clean && bear -- make all` 成功。
+- commit: `phase-1: Ex bootstrap runtime and launch facade` (`4daafbf`)
+
+### Phase 2 开始
+agent 正在启动 Phase 2: Demo Launch Cutover 实施。
+- 当前策略：将 `user_hello` 切到 Ex facade，同时只把 trampoline 和 timer 的 bootstrap 判定切到 Ex ownership query；finalizer/reaper 留到 Phase 3 统一处理。
+- impl 已完成 Phase 2：`user_hello` 已迁移到 Ex bootstrap facade，Ke bootstrap callback contract 增加 thread ownership query，trampoline 与 timer observe 改为通过 Ex registry 判断。
+- reviewer PASS：确认本阶段改动在当前单 bootstrap-thread 模型下自洽，未发现阻塞问题。
+- 验证结果：`make clean && bear -- make all BUILD_FLAVOR=test-user_hello HO_DEMO_TEST_NAME=user_hello HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_USER_HELLO` 成功；`qemu_capture.sh` 日志锚点保持不变，包含 `enter user mode`、`timer from user #1/#2`、`invalid raw write rejected`、`hello write succeeds`、`SYS_RAW_EXIT`、`bootstrap teardown complete`、`idle/reaper reclaimed`。
+- commit: `phase-2: cut over user_hello launch to Ex facade` (`86c974c`)
+
+### Phase 3 开始
+agent 正在启动 Phase 3: Ke Residue Removal 实施。
+- 当前策略：删除 `KTHREAD_FLAG_BOOTSTRAP_USER` 与 `UserBootstrapContext`，让 staging/ownership 全部通过 Ex 内部 registry 查询；clean `SYS_RAW_EXIT` 由 Ex helper 销毁 staging，但保留最小 Ex wrapper 直到 finalizer/reaper 消费完 bootstrap identity。
+- impl 已完成 Phase 3：新增 Ex-owned bootstrap ABI 头；finalizer/reaper 切到 Ex ownership query；`SYS_RAW_EXIT` 改为 Ex helper teardown；`KTHREAD_FLAG_BOOTSTRAP_USER` 与 `UserBootstrapContext` 已删除；demo 和 arch 不再直接 include `kernel/ke/user_bootstrap.h`。
+- reviewer PASS：确认 Phase 3 在当前单 bootstrap-thread registry 模型下自洽，未发现阻塞问题。
+- 静态校验：残留字段全仓引用已清空，受影响文件诊断无错误。
+- commit: `phase-3: remove Ke bootstrap residue` (`7b050b2`)
+
+### Phase 4 开始
+agent 正在启动 Phase 4: Validation And Documentation Sync 实施。
+- 4.1: `make clean && bear -- make all BUILD_FLAVOR=test-user_hello HO_DEMO_TEST_NAME=user_hello HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_USER_HELLO` 成功，生成 `build/kernel/test-user_hello/bin/kernel.bin`。
+- 4.2: `BUILD_FLAVOR=test-user_hello HO_DEMO_TEST_NAME=user_hello HO_DEMO_TEST_DEFINE=HO_DEMO_TEST_USER_HELLO bash scripts/qemu_capture.sh 30 /tmp/himuos-user-hello.log` 已重跑；串口日志保持 `enter user mode`、`timer from user #1/#2`、`P1 gate armed`、`invalid raw write rejected`、`hello write succeeds`、`SYS_RAW_EXIT`、`bootstrap teardown complete`、`idle/reaper reclaimed` 锚点。脚本按 bounded capture 预期以 124 结束。
+- 4.3: 已同步更新 `docs/current-ability.md` 与 `docs/draft/userspace.md`，明确 Ex 已成为 bootstrap launch/init/teardown owner，正式地址空间语义从 Phase B 才开始承接。
+- reviewer PASS：文档与当前实现一致，未发现阻塞问题。
+- 所有 tasks 完成
+

--- a/docs/current-ability.md
+++ b/docs/current-ability.md
@@ -1,6 +1,6 @@
 # HimuOS 当前能力盘点
 
-更新时间：2026-04-03
+更新时间：2026-04-04
 
 ## 盘点口径
 
@@ -9,7 +9,7 @@
 本次盘点综合了四类信息源：
 
 - `Readme.md`：对外承诺、回归 profile 说明与阶段边界
-- 当前 `main` 工作树与最近提交：尤其是 `origin/main` 之后的 P3 本地提交 `4f27a92`、`c7c3e2e`、`fea4e66`
+- 当前工作树与最近提交：尤其是 `origin/main` 之后围绕 P3 exit/reap 与 `complete-ex-bootstrap-migration` 的本地提交
 - 已合并 PR：近期重点参考 `#29`～`#33`，其中与最小用户态切片直接相关的是 `#31`、`#32`、`#33`
 - 当前源码与 OpenSpec：归档 change 用来确认既有合同，活跃 change 用来核对边界、非目标与仍在推进的表述
 
@@ -28,12 +28,13 @@
 - 已合并 PR `#31` 把 `user_hello` 固定成 bootstrap-only 的最小 Ring 3 bring-up 切片
 - 已合并 PR `#32` 把 P1 first-entry / timer round-trip 证据正式收敛到同一个 `user_hello` profile
 - 已合并 PR `#33` 把 P2 rejected raw write probe / successful hello write / `SYS_RAW_EXIT` 证据链固定下来
-- 当前 HEAD 的 3 个本地提交继续把 P3 收敛为显式合同：`SYS_RAW_EXIT` 后的 `bootstrap teardown complete` 锚点、scheduler finalizer 的 `fallback staging reclaim` 警告锚点，以及相应注释/文档同步
-- `openspec/changes/add-user-bootstrap-p1-evidence` 与 `openspec/changes/stabilize-user-bootstrap-p2-raw-syscalls` 对应能力已经在代码和 merged PR 中落地但尚未归档；`openspec/changes/stabilize-user-bootstrap-p3-exit-reap` 仍是活跃 change，不过当前 HEAD 已经补上它最关键的 clean-pass 日志与文档语义
+- 当前 HEAD 的 `complete-ex-bootstrap-migration` 已把 bootstrap launch / init / teardown 所有权收口到 Ex：`user_hello` 通过 Ex facade 启动，`InitKernel()` 通过 `ExBootstrapInit()` 统一装配 bootstrap runtime
+- bootstrap ABI 常量、固定窗口约束说明和关键日志锚点现已由 `src/include/kernel/ex/ex_bootstrap_abi.h` 对外暴露；scheduler / timer / finalizer / reaper 通过 Ex 注册的 ownership query 与 callbacks 判断 bootstrap 路径，`KTHREAD_FLAG_BOOTSTRAP_USER` 与 `UserBootstrapContext` 已删除
+- 正式进程地址空间 / 独立 CR3 语义仍未开始落地；这部分从 `complete-ex-bootstrap-migration` 的 Phase B 才开始承接
 
 ## 当前已支持的功能
 
-整体上，HimuOS 当前已经是一个**以 Ke 层为主、并带有一条 bootstrap-only 最小用户态切片的教学原型系统**：启动、内存、时间、控制台、中断、调度、同步、诊断、回归 profile 都已经具备明确实现；另外，独立 `user_hello` profile 已打通最小 Ring 3 bring-up、P1 timer round-trip、P2 raw syscall 自检，并在当前 HEAD 上进一步把 P3 的 teardown-before-termination -> idle/reaper reclaim 证据链固定成显式合同，但这还不能等同于完整用户态子系统。
+整体上，HimuOS 当前已经是一个**仍以 Ke 层为主、但 bootstrap launch / init / teardown 已收口到 Ex 的教学原型系统**：启动、内存、时间、控制台、中断、调度、同步、诊断、回归 profile 都已经具备明确实现；另外，独立 `user_hello` profile 已打通最小 Ring 3 bring-up、P1 timer round-trip、P2 raw syscall 自检，并在当前 HEAD 上进一步把 P3 的 teardown-before-termination -> idle/reaper reclaim 证据链固定成显式合同，但这还不能等同于完整用户态子系统。
 
 | 能力域 | 结论 | 主要依据 |
 | --- | --- | --- |
@@ -55,8 +56,8 @@
 | 固定大小对象池 | 已有 | `src/kernel/ke/mm/pool.c`、`src/include/kernel/ke/pool.h`，OpenSpec `kernel-object-pool` |
 | 系统信息查询（sysinfo） | 已有 | `src/kernel/ke/sysinfo/sysinfo.c`、`src/include/kernel/ke/sysinfo.h`，已支持 CPU、页表、内存、GDT/TSS/IDT、时间、scheduler、VMM 等查询 |
 | 内核线程（KTHREAD） | 已有 | `src/kernel/ke/thread/kthread.c`、`src/include/kernel/ke/kthread.h`，支持创建 joinable / detached 线程 |
-| bootstrap-only 最小用户态执行路径 | 已有 | `src/kernel/demo/user_hello.c`、`src/kernel/ke/user_bootstrap.c`、`src/kernel/ke/user_bootstrap_syscall.c`、`src/arch/amd64/user_bootstrap.asm`、`src/kernel/ke/thread/scheduler/scheduler.c` 已打通独立 `user_hello` profile 下的 staging 用户映射、首次进入 Ring 3、来自 CPL3 的 P1 timer round-trip、P2 raw syscall 证据链，并用 `bootstrap teardown complete` / `fallback staging reclaim` 锚点明确 P3 teardown-before-termination → idle/reaper reclaim 合同；scheduler / timer 中的 bootstrap 硬编码分支已收口为 Ke 回调槽位，由 `src/kernel/ex/ex_bootstrap_adapter.c` 注册实现 |
-| 最小 raw syscall 入口 | 已有 | `src/include/kernel/ke/user_bootstrap.h`、`src/kernel/ke/user_bootstrap_syscall.c`、`src/kernel/init/init.c` 已实现同步 `int 0x80` 入口、`SYS_RAW_WRITE` / `SYS_RAW_EXIT`、bootstrap user-range 校验与 bounded copy-in helper，以及 P2/P3 稳定日志锚点 |
+| bootstrap-only 最小用户态执行路径 | 已有 | `src/kernel/demo/user_hello.c`、`src/kernel/ex/ex_bootstrap.c`、`src/kernel/ex/ex_bootstrap_adapter.c`、`src/kernel/ke/user_bootstrap.c`、`src/kernel/ke/user_bootstrap_syscall.c`、`src/arch/amd64/user_bootstrap.asm` 已打通独立 `user_hello` profile 下的 staging 用户映射、首次进入 Ring 3、来自 CPL3 的 P1 timer round-trip、P2 raw syscall 证据链，并用 `bootstrap teardown complete` / `fallback staging reclaim` 锚点明确 P3 teardown-before-termination → idle/reaper reclaim 合同；当前 bootstrap launch / init / teardown owner 已收口到 Ex，`user_hello` 经由 Ex facade 启动，scheduler / timer / finalizer / reaper 通过 Ex ownership query / callbacks 判断 bootstrap 路径，`KTHREAD_FLAG_BOOTSTRAP_USER` 与 `UserBootstrapContext` 已删除 |
+| 最小 raw syscall 入口 | 已有 | `src/include/kernel/ex/ex_bootstrap.h`、`src/include/kernel/ex/ex_bootstrap_abi.h`、`src/kernel/ex/ex_bootstrap.c`、`src/kernel/ke/user_bootstrap_syscall.c`、`src/kernel/init/init.c` 已实现同步 `int 0x80` 入口、`SYS_RAW_WRITE` / `SYS_RAW_EXIT`、bootstrap user-range 校验与 bounded copy-in helper，以及 P2/P3 稳定日志锚点；bootstrap ABI 常量、固定窗口语义和外部可见证据锚点现由 Ex 头文件暴露，而 trap / copy-in 机制仍由 Ke 提供 |
 | 调度器 | 已有 | `src/kernel/ke/thread/scheduler/scheduler.c`、`timer.c`、`diag.c`，OpenSpec `scheduler` / `scheduler-observability` |
 | 单对象等待模型 | 已有 | `src/kernel/ke/thread/scheduler/wait.c`，提供 `KeWaitForSingleObject` 与统一 wait-completion 路径，OpenSpec `dispatcher-objects` |
 | 事件（KEVENT） | 已有 | `src/kernel/ke/thread/scheduler/sync.c`、`src/include/kernel/ke/event.h`、OpenSpec `kevent` |
@@ -75,7 +76,7 @@
 
 这里的用户态能力只指独立 `user_hello` profile 下的最小执行路径与 raw syscall 入口，不应外推为完整进程地址空间、正式系统调用子系统或 Ex 层对象模型。
 
-更具体地说，当前 `user_hello` 只是一条 bootstrap/staging 性质的脚手架测试路径，用来验证“最小用户页映射 -> 首次进入 Ring 3 -> 来自 CPL3 的 P1 timer round-trip -> P1 gate armed -> invalid raw write rejected -> hello write succeeds -> `SYS_RAW_EXIT` -> bootstrap teardown complete -> thread terminated -> idle/reaper reclaimed -> back to idle”这条最小证据链。这里的 P1 gate、后续 P2 raw syscall 自检以及当前 HEAD 上进一步补强的 P3 exit/reap 合同，都只是同一个 `user_hello` profile 内部的分阶段验证，不是新增独立的 P1-only、P2-only 或 P3-only profile。现阶段共享 imported root 仍保留 boot 阶段遗留的低 2GB identity mapping，因此 bootstrap 固定用户窗口需要显式避开该区域；这属于当前 bring-up 模型的临时约束，不代表长期用户虚拟地址布局合同，也不意味着当前 bootstrap raw syscall 已经承诺未来正式用户态 ABI。P3 现在明确要求正常路径由 `SYS_RAW_EXIT` 在进入 `KeThreadExit()` 前完成 bootstrap 用户资源释放并打印 `bootstrap teardown complete`，scheduler finalizer 只保留 `fallback staging reclaim` 这类防御性兜底语义。后续引入真实 ELF 加载器与正式用户地址空间时，系统预期会为用户态重建或派生独立页表根，并以干净的 low-half 布局替代当前 fixed bootstrap window，因此这条 staging 限制与长期目标并不冲突。
+更具体地说，当前 `user_hello` 只是一条 bootstrap/staging 性质的脚手架测试路径，用来验证“最小用户页映射 -> 首次进入 Ring 3 -> 来自 CPL3 的 P1 timer round-trip -> P1 gate armed -> invalid raw write rejected -> hello write succeeds -> `SYS_RAW_EXIT` -> bootstrap teardown complete -> thread terminated -> idle/reaper reclaimed -> back to idle”这条最小证据链。当前 launch / init / teardown 与对外 bootstrap ABI surface 已由 Ex facade 持有，Ke 继续负责 staging、trap、线程与调度等底层机制；当前代码也已经删除 `KTHREAD_FLAG_BOOTSTRAP_USER` 与 `UserBootstrapContext`，因此 scheduler / timer / finalizer / idle/reaper 只通过 Ex 注册的 ownership query / callback contract 判断是否走 bootstrap 路径。这里的 P1 gate、后续 P2 raw syscall 自检以及当前 HEAD 上进一步补强的 P3 exit/reap 合同，都只是同一个 `user_hello` profile 内部的分阶段验证，不是新增独立的 P1-only、P2-only 或 P3-only profile。现阶段共享 imported root 仍保留 boot 阶段遗留的低 2GB identity mapping，因此 bootstrap 固定用户窗口需要显式避开该区域；这属于当前 bring-up 模型的临时约束，不代表长期用户虚拟地址布局合同，也不意味着当前 bootstrap raw syscall 已经承诺未来正式用户态 ABI。P3 现在明确要求正常路径由 `SYS_RAW_EXIT` 在进入 `KeThreadExit()` 前完成 bootstrap 用户资源释放并打印 `bootstrap teardown complete`，scheduler finalizer 只保留 `fallback staging reclaim` 这类防御性兜底语义。而 `complete-ex-bootstrap-migration` 的 Phase B 才开始承接正式地址空间语义：届时系统预期会为用户态重建或派生独立页表根，并以干净的 low-half 布局替代当前 fixed bootstrap window，因此这条 staging 限制与长期目标并不冲突。
 
 它已经不只是“能启动的内核骨架”，而是具备以下连续能力链：
 
@@ -103,9 +104,9 @@
 | 待完成功能 | 为什么仍算缺口 | 现有状态 |
 | --- | --- | --- |
 | 完整用户态子系统 / 通用用户程序模型 | README 明确承诺“内核态与用户态安全隔离” | 当前只有挂在独立 `user_hello` profile 下的 bootstrap-only 最小执行路径，尚不具备通用用户程序装载、可恢复故障或稳定用户对象模型 |
-| 正式进程地址空间 / 进程级地址空间切换 | README 把虚拟内存目标描述为“为内核和用户程序提供隔离地址空间” | 当前用户页仍以 staging 方式挂在 imported root 上，不是正式进程地址空间模型 |
+| 正式进程地址空间 / 进程级地址空间切换 | README 把虚拟内存目标描述为“为内核和用户程序提供隔离地址空间” | 这部分从 `complete-ex-bootstrap-migration` 的 Phase B 才开始承接；当前用户页仍以 staging 方式挂在 imported root 上，不是正式进程地址空间模型 |
 | handle-oriented 正式 syscall 表面 | README 明确承诺“系统调用是用户态获取内核服务的唯一入口” | 当前只有同步 `int 0x80` 的 bootstrap raw syscall 入口，且 ABI 仅限 `SYS_RAW_WRITE` / `SYS_RAW_EXIT`，还不是正式的 handle-oriented syscall 接口 |
-| Ex 层 / Object Manager | 只有 bootstrap 适配薄壳 | 当前已引入 `src/kernel/ex/` 目录与极薄的 `ExProcess` / `ExThread` bootstrap 适配层，scheduler / timer 已通过 Ke 回调槽位分发 bootstrap 语义；但仍不具备正式对象管理器、对象命名/生命周期框架或通用进程模型 |
+| Ex 层 / Object Manager | 只有 bootstrap 适配薄壳 | 当前 Ex 已成为 bootstrap launch / init / teardown owner，并对外暴露 bootstrap facade / ABI；但这仍只是 bootstrap-only 薄运行时，不具备正式对象管理器、对象命名/生命周期框架或通用进程模型 |
 | Capability 句柄模型 | README 把它作为用户态/内核态隔离的重要机制 | 当前没有对象句柄表、capability 校验、句柄引用/销毁等子系统 |
 | 优先级调度 | README 承诺“基于优先级和时间片轮转（RR）的调度器” | 当前 OpenSpec `scheduler` 与代码都明确是**单优先级 RR**；`KTHREAD.Priority` 只是保留字段 |
 | 键盘循环缓冲输入 | README 明确承诺“键盘循环缓冲输入”与“标准 QWERTY 键盘输入支持” | 当前没有内核键盘驱动、扫描码处理或输入缓冲队列；只有 bootloader 的 UEFI 文本输入 |
@@ -121,7 +122,7 @@
 
 当前的 HimuOS 更准确的定位是：
 
-- **已经完成的部分**：UEFI 启动、Ke 层核心机制、内核内存管理、线程调度与同步、诊断与教学回归 profile，以及挂在 `user_hello` 上的 bootstrap-only P1/P2/P3 最小用户态证据链
+- **已经完成的部分**：UEFI 启动、Ke 层核心机制、内核内存管理、线程调度与同步、诊断与教学回归 profile，以及挂在 `user_hello` 上、由 Ex 持有 launch / init / teardown owner 的 bootstrap-only P1/P2/P3 最小用户态证据链
 - **尚未完成的部分**：README 中更接近“完整 OS 对外语义”的那一层，尤其是正式进程地址空间、handle-oriented syscall、Ex/Object Manager、capability handle、键盘输入、优先级调度
 
 换句话说，当前系统已经是一个**功能明确、结构清晰的内核教学原型**，其中还带有一条 bootstrap-only 的最小用户态 bring-up 路径；但它还**不是** README 最初叙述里的那个“具备正式进程地址空间 / handle-oriented syscall / Ex 层对象模型”的更完整版本。

--- a/docs/current-ability.md
+++ b/docs/current-ability.md
@@ -55,7 +55,7 @@
 | 固定大小对象池 | 已有 | `src/kernel/ke/mm/pool.c`、`src/include/kernel/ke/pool.h`，OpenSpec `kernel-object-pool` |
 | 系统信息查询（sysinfo） | 已有 | `src/kernel/ke/sysinfo/sysinfo.c`、`src/include/kernel/ke/sysinfo.h`，已支持 CPU、页表、内存、GDT/TSS/IDT、时间、scheduler、VMM 等查询 |
 | 内核线程（KTHREAD） | 已有 | `src/kernel/ke/thread/kthread.c`、`src/include/kernel/ke/kthread.h`，支持创建 joinable / detached 线程 |
-| bootstrap-only 最小用户态执行路径 | 已有 | `src/kernel/demo/user_hello.c`、`src/kernel/ke/user_bootstrap.c`、`src/kernel/ke/user_bootstrap_syscall.c`、`src/arch/amd64/user_bootstrap.asm`、`src/kernel/ke/thread/scheduler/scheduler.c` 已打通独立 `user_hello` profile 下的 staging 用户映射、首次进入 Ring 3、来自 CPL3 的 P1 timer round-trip、P2 raw syscall 证据链，并用 `bootstrap teardown complete` / `fallback staging reclaim` 锚点明确 P3 teardown-before-termination → idle/reaper reclaim 合同 |
+| bootstrap-only 最小用户态执行路径 | 已有 | `src/kernel/demo/user_hello.c`、`src/kernel/ke/user_bootstrap.c`、`src/kernel/ke/user_bootstrap_syscall.c`、`src/arch/amd64/user_bootstrap.asm`、`src/kernel/ke/thread/scheduler/scheduler.c` 已打通独立 `user_hello` profile 下的 staging 用户映射、首次进入 Ring 3、来自 CPL3 的 P1 timer round-trip、P2 raw syscall 证据链，并用 `bootstrap teardown complete` / `fallback staging reclaim` 锚点明确 P3 teardown-before-termination → idle/reaper reclaim 合同；scheduler / timer 中的 bootstrap 硬编码分支已收口为 Ke 回调槽位，由 `src/kernel/ex/ex_bootstrap_adapter.c` 注册实现 |
 | 最小 raw syscall 入口 | 已有 | `src/include/kernel/ke/user_bootstrap.h`、`src/kernel/ke/user_bootstrap_syscall.c`、`src/kernel/init/init.c` 已实现同步 `int 0x80` 入口、`SYS_RAW_WRITE` / `SYS_RAW_EXIT`、bootstrap user-range 校验与 bounded copy-in helper，以及 P2/P3 稳定日志锚点 |
 | 调度器 | 已有 | `src/kernel/ke/thread/scheduler/scheduler.c`、`timer.c`、`diag.c`，OpenSpec `scheduler` / `scheduler-observability` |
 | 单对象等待模型 | 已有 | `src/kernel/ke/thread/scheduler/wait.c`，提供 `KeWaitForSingleObject` 与统一 wait-completion 路径，OpenSpec `dispatcher-objects` |
@@ -105,7 +105,7 @@
 | 完整用户态子系统 / 通用用户程序模型 | README 明确承诺“内核态与用户态安全隔离” | 当前只有挂在独立 `user_hello` profile 下的 bootstrap-only 最小执行路径，尚不具备通用用户程序装载、可恢复故障或稳定用户对象模型 |
 | 正式进程地址空间 / 进程级地址空间切换 | README 把虚拟内存目标描述为“为内核和用户程序提供隔离地址空间” | 当前用户页仍以 staging 方式挂在 imported root 上，不是正式进程地址空间模型 |
 | handle-oriented 正式 syscall 表面 | README 明确承诺“系统调用是用户态获取内核服务的唯一入口” | 当前只有同步 `int 0x80` 的 bootstrap raw syscall 入口，且 ABI 仅限 `SYS_RAW_WRITE` / `SYS_RAW_EXIT`，还不是正式的 handle-oriented syscall 接口 |
-| Ex 层 / Object Manager | README 明确写了 Ke/Ex 两层结构，Ex 层负责对象管理器 | 当前仓库基本只有 Ke 层；没有独立的 Ex 层目录、对象管理器或对象命名/生命周期框架 |
+| Ex 层 / Object Manager | 只有 bootstrap 适配薄壳 | 当前已引入 `src/kernel/ex/` 目录与极薄的 `ExProcess` / `ExThread` bootstrap 适配层，scheduler / timer 已通过 Ke 回调槽位分发 bootstrap 语义；但仍不具备正式对象管理器、对象命名/生命周期框架或通用进程模型 |
 | Capability 句柄模型 | README 把它作为用户态/内核态隔离的重要机制 | 当前没有对象句柄表、capability 校验、句柄引用/销毁等子系统 |
 | 优先级调度 | README 承诺“基于优先级和时间片轮转（RR）的调度器” | 当前 OpenSpec `scheduler` 与代码都明确是**单优先级 RR**；`KTHREAD.Priority` 只是保留字段 |
 | 键盘循环缓冲输入 | README 明确承诺“键盘循环缓冲输入”与“标准 QWERTY 键盘输入支持” | 当前没有内核键盘驱动、扫描码处理或输入缓冲队列；只有 bootloader 的 UEFI 文本输入 |

--- a/docs/draft/userspace.md
+++ b/docs/draft/userspace.md
@@ -1,0 +1,58 @@
+# HimuOS 架构决议报告：先立薄 Ex 边界，再塑独立地址空间
+
+## 决议概述
+
+经过对当前代码库的依赖关系与分层债务评估，团队就“先做 Ex 层还是先做独立地址空间”达成混合共识：**采纳方案 2 的时序（先 Ex），并严格施加方案 1 的范围约束（极薄化）**。
+
+核心路线定调为：**优先引入极薄的 Ex（执行体）边界，确立进程生命周期与资源归属权；紧接着实现正式的独立用户地址空间机制。** 当前阶段严禁横向铺开完整的对象管理器（Object Manager）、Capability 句柄表或正式系统调用（Syscall）表面。
+
+---
+
+## 架构痛点与决策依据
+
+当前系统虽然成功跑通了 `user_hello` 的 P1-P3 最小证据链，但为了快速验证，用户态语义已经严重侵入了 Ke（内核）层的核心机制。若直接在此时推进独立地址空间，会导致架构污染进一步加剧。
+
+| 污染位置 | 当前现状 | 若“先做地址空间”的恶化后果 | 引入薄 Ex 层的解决方案 |
+| :--- | :--- | :--- | :--- |
+| **KTHREAD 结构体** | 挂载了 `UserBootstrapContext` 指针与 `KTHREAD_FLAG_BOOTSTRAP_USER`。 | 地址空间指针将被迫继续塞入 `KTHREAD`，导致机制与策略彻底混用。 | 将这些字段上移至新创建的 `EPROCESS` / `ETHREAD` 结构中。 |
+| **调度器 Trampoline** | 硬编码检查上述指针以决定是否进入 Ring 3。 | 切换 CR3 的逻辑将被硬编码进 Ke 的线程分发器。 | 改为注册式回调，调度器只负责触发，Ex 层决定是否执行用户态转换。 |
+| **线程 Finalizer** | 包含 `fallback staging reclaim` 等特定的资源回收硬编码逻辑。 | 页表销毁逻辑将侵入通用的内核线程回收流。 | 回收逻辑封装至 Ex 层的生命周期管理（Teardown）中。 |
+| **系统调用分发** | Raw syscall 逻辑直接存放在 `ke/` 目录下。 | 将错就错，导致 Ke 层成为用户态特例的收容所。 | 将相关逻辑平移至 Ex 层或由 Ex 层进行合理封装。 |
+
+**核心结论**：`EPROCESS` 天然是独立地址空间（PML4 根）的归属者（Owner）。没有这个所有者，新的页表机制在 Ke 层无处安放。先立边界，可以避免在错误的层级建造“准进程”容器并反复推倒重来。
+
+---
+
+## 两阶段实施路线图
+
+为了平稳过渡并清偿技术债，开发工作将拆分为两个连续的阶段：
+
+### Phase A：建立极薄 Ex 层（收口当前状态）
+
+此阶段的目标是**重构而非增加新特性**，重点在于将 Ke 层清理干净，维持 `user_hello` 日志锚点和证据链不变。
+
+* **创建薄对象**：实现最基础的 `ExProcess` 和 `ExThread`。`ExProcess` 负责持有当前的 staging 状态和生命周期；`ExThread` 作为包裹 `KTHREAD` 的上层容器。
+* **净化 Ke 层**：从 `KTHREAD` 中彻底移除 `UserBootstrapContext` 和 `KTHREAD_FLAG_BOOTSTRAP_USER`。
+* **引入回调机制**：在 Scheduler 中替换硬编码的用户态特判，引入 `KiThreadEnterCallback` 与 `KiThreadFinalizeCallback`，由 Ex 层在初始化时注册具体实现。
+* **重构测试入口**：修改 `user_hello.c` 演示流，统一通过 `ExCreateProcess()` -> `ExCreateThread()` -> `ExStartThread()` 链条启动。
+* **目录规整**：将 `user_bootstrap.c` 与 `user_bootstrap_syscall.c` 移交 Ex 层管理或封装。
+
+### Phase B：落地独立用户地址空间机制
+
+在 Phase A 确立了 `EPROCESS` 作为合法的资源归属者后，顺理成章地推进内存机制的演进。
+
+* **升级归属权**：`EPROCESS.AddressSpace` 的语义从“引用共享 imported root”升级为“持有独立的 PML4 根并克隆内核高半区”。
+* **Ke 提供纯机制**：Ke 层新增 `KeSwitchAddressSpace(phys_addr)` 接口，仅负责 CR3 寄存器写入与 TLB 刷新，不包含任何策略逻辑。
+* **Ex 负责触发**：Ex 层通过挂载在进程切换路径上的回调，调用上述机制接口完成地址空间切换。
+* **解除固定约束**：将 Staging Payload 直接映射进进程专属的地址空间根中，彻底废除 `0x80000000` 固定窗口的早期约束。
+
+---
+
+## 严格防范的范围蔓延（Out of Scope）
+
+为避免过度设计阻碍 Phase B 的交付，以下组件在当前及下一阶段中**明确不予实施**：
+
+* **KPROCESS**：暂不引入内核级进程抽象，除非 Phase B 在处理 CR3 切换机制时发现非其不可。
+* **Handle Table / Capability**：对象句柄表和能力模型推迟至 Phase C。
+* **正式 Syscall 表面**：面向对象的标准系统调用体系推迟至 Phase D。
+* **ELF Loader**：动态可执行文件加载器推迟至 Phase E。

--- a/docs/draft/userspace.md
+++ b/docs/draft/userspace.md
@@ -6,13 +6,15 @@
 
 核心路线定调为：**优先引入极薄的 Ex（执行体）边界，确立进程生命周期与资源归属权；紧接着实现正式的独立用户地址空间机制。** 当前阶段严禁横向铺开完整的对象管理器（Object Manager）、Capability 句柄表或正式系统调用（Syscall）表面。
 
+> 注：下文“架构痛点”“当前现状”等描述保留的是本决议提出时的背景状态。当前 HEAD 已完成 Phase A 中关于 bootstrap launch / init / teardown owner 的收口：`user_hello` 现经 Ex facade 启动，`InitKernel()` 通过 `ExBootstrapInit()` 统一装配 runtime，`KTHREAD_FLAG_BOOTSTRAP_USER` 与 `UserBootstrapContext` 已删除，scheduler / timer / finalizer / reaper 通过 Ex ownership query / callback contract 判断 bootstrap 路径。保留这些旧表述是为了说明为何要先立薄 Ex 边界，不表示这些 Ke 残留今天仍然存在。
+
 ---
 
 ## 架构痛点与决策依据
 
-当前系统虽然成功跑通了 `user_hello` 的 P1-P3 最小证据链，但为了快速验证，用户态语义已经严重侵入了 Ke（内核）层的核心机制。若直接在此时推进独立地址空间，会导致架构污染进一步加剧。
+在本决议提出时，系统虽然成功跑通了 `user_hello` 的 P1-P3 最小证据链，但为了快速验证，用户态语义已经严重侵入了 Ke（内核）层的核心机制。若直接在此时推进独立地址空间，会导致架构污染进一步加剧。
 
-| 污染位置 | 当前现状 | 若“先做地址空间”的恶化后果 | 引入薄 Ex 层的解决方案 |
+| 污染位置 | 决议前现状 | 若“先做地址空间”的恶化后果 | 引入薄 Ex 层的解决方案 |
 | :--- | :--- | :--- | :--- |
 | **KTHREAD 结构体** | 挂载了 `UserBootstrapContext` 指针与 `KTHREAD_FLAG_BOOTSTRAP_USER`。 | 地址空间指针将被迫继续塞入 `KTHREAD`，导致机制与策略彻底混用。 | 将这些字段上移至新创建的 `EPROCESS` / `ETHREAD` 结构中。 |
 | **调度器 Trampoline** | 硬编码检查上述指针以决定是否进入 Ring 3。 | 切换 CR3 的逻辑将被硬编码进 Ke 的线程分发器。 | 改为注册式回调，调度器只负责触发，Ex 层决定是否执行用户态转换。 |
@@ -37,9 +39,11 @@
 * **重构测试入口**：修改 `user_hello.c` 演示流，统一通过 `ExCreateProcess()` -> `ExCreateThread()` -> `ExStartThread()` 链条启动。
 * **目录规整**：将 `user_bootstrap.c` 与 `user_bootstrap_syscall.c` 移交 Ex 层管理或封装。
 
+注：上述收口已在当前 HEAD 落地，当前文档保留它们作为 Phase A 的决议目标与实施依据。正式进程地址空间 / 独立 CR3 语义仍未进入当前实现，按本决议仍归入 Phase B。
+
 ### Phase B：落地独立用户地址空间机制
 
-在 Phase A 确立了 `EPROCESS` 作为合法的资源归属者后，顺理成章地推进内存机制的演进。
+在 Phase A 确立了 `EPROCESS` 作为合法的资源归属者后，顺理成章地推进内存机制的演进。**正式地址空间语义从这一阶段才开始承接。**
 
 * **升级归属权**：`EPROCESS.AddressSpace` 的语义从“引用共享 imported root”升级为“持有独立的 PML4 根并克隆内核高半区”。
 * **Ke 提供纯机制**：Ke 层新增 `KeSwitchAddressSpace(phys_addr)` 接口，仅负责 CR3 寄存器写入与 TLB 刷新，不包含任何策略逻辑。

--- a/makefile
+++ b/makefile
@@ -218,8 +218,10 @@ SRCS_KERNEL_C := \
     src/kernel/ke/mm/kva.c                              \
     src/kernel/ke/mm/allocator.c                        \
     src/kernel/ke/mm/pool.c                             \
+	src/kernel/ke/bootstrap_callbacks.c                 \
 	src/kernel/ke/user_bootstrap.c                      \
 	src/kernel/ke/user_bootstrap_syscall.c              \
+	src/kernel/ex/ex_bootstrap_adapter.c                \
     src/kernel/ke/thread/kthread.c                      \
     src/kernel/ke/thread/scheduler/scheduler.c          \
     src/kernel/ke/thread/scheduler/wait.c               \

--- a/makefile
+++ b/makefile
@@ -221,6 +221,7 @@ SRCS_KERNEL_C := \
 	src/kernel/ke/bootstrap_callbacks.c                 \
 	src/kernel/ke/user_bootstrap.c                      \
 	src/kernel/ke/user_bootstrap_syscall.c              \
+	src/kernel/ex/ex_bootstrap.c                        \
 	src/kernel/ex/ex_bootstrap_adapter.c                \
     src/kernel/ke/thread/kthread.c                      \
     src/kernel/ke/thread/scheduler/scheduler.c          \

--- a/src/arch/amd64/idt.c
+++ b/src/arch/amd64/idt.c
@@ -1,9 +1,9 @@
 #include "arch/amd64/idt.h"
 #include "arch/amd64/pm.h"
 #include "kernel/hodbg.h"
+#include <kernel/ex/ex_bootstrap_abi.h>
 #include <kernel/init.h>
 #include <kernel/ke/irql.h>
-#include <kernel/ke/user_bootstrap.h>
 #include <libc/string.h>
 
 static IDT_ENTRY kInterruptDescriptorTable[256];

--- a/src/include/kernel/ex/ex_bootstrap.h
+++ b/src/include/kernel/ex/ex_bootstrap.h
@@ -1,0 +1,55 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ex/ex_bootstrap.h
+ * Description: Ex-owned bootstrap runtime and launch facade.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <_hobase.h>
+
+#include <kernel/ex/ex_process.h>
+#include <kernel/ex/ex_thread.h>
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS ExBootstrapInit(void);
+
+/**
+ * Create an owning bootstrap process handle for a staged user image.
+ * The caller owns the returned handle until it is either destroyed explicitly
+ * or consumed by ExBootstrapCreateThread().
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS ExBootstrapCreateProcess(const EX_BOOTSTRAP_PROCESS_CREATE_PARAMS *params,
+                                                              EX_PROCESS **outProcess);
+
+/**
+ * Destroy an owning bootstrap process handle that has not been transferred to
+ * a bootstrap thread.
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS ExBootstrapDestroyProcess(EX_PROCESS *process);
+
+/**
+ * Create a bootstrap thread and transfer process ownership into it.
+ * On success this consumes *processHandle, sets it to NULL, and returns a new
+ * owning EX_THREAD handle in *outThread.
+ * On failure *processHandle remains owned by the caller.
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS ExBootstrapCreateThread(EX_PROCESS **processHandle,
+                                                             const EX_BOOTSTRAP_THREAD_CREATE_PARAMS *params,
+                                                             EX_THREAD **outThread);
+
+/**
+ * Start a bootstrap thread and transfer thread ownership to the runtime.
+ * On success this consumes *threadHandle, sets it to NULL, and the runtime
+ * finalizer becomes responsible for teardown.
+ * On failure *threadHandle remains owned by the caller.
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS ExBootstrapStartThread(EX_THREAD **threadHandle);
+
+/**
+ * Cancel a bootstrap thread before it has been started.
+ * Only threads still in the NEW state can be torn down here; once started,
+ * teardown is owned by the runtime finalizer.
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS ExBootstrapTeardownThread(EX_THREAD *thread);

--- a/src/include/kernel/ex/ex_bootstrap_abi.h
+++ b/src/include/kernel/ex/ex_bootstrap_abi.h
@@ -1,0 +1,78 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ex/ex_bootstrap_abi.h
+ * Description: Ex-owned bootstrap ABI constants and evidence-chain anchors.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <_hobase.h>
+
+/*
+ * The fixed low-half user window below is a staging/bootstrap model only.
+ * It reuses the shared imported kernel root for the first user-mode slice and
+ * must not be treated as the long-term per-process address-space contract.
+ * Keep it above the boot-time low 2GB identity import so hole validation sees
+ * an unmapped slot in the shared root.
+ */
+#define KE_USER_BOOTSTRAP_PAGE_SIZE              0x1000ULL
+#define KE_USER_BOOTSTRAP_WINDOW_BASE            0x0000000080000000ULL
+#define KE_USER_BOOTSTRAP_WINDOW_PAGE_COUNT      4ULL
+#define KE_USER_BOOTSTRAP_WINDOW_END_EXCLUSIVE   (KE_USER_BOOTSTRAP_WINDOW_BASE +                     \
+                                                  (KE_USER_BOOTSTRAP_WINDOW_PAGE_COUNT *              \
+                                                   KE_USER_BOOTSTRAP_PAGE_SIZE))
+#define KE_USER_BOOTSTRAP_CODE_BASE              KE_USER_BOOTSTRAP_WINDOW_BASE
+#define KE_USER_BOOTSTRAP_CONST_BASE             (KE_USER_BOOTSTRAP_CODE_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
+#define KE_USER_BOOTSTRAP_STACK_GUARD_BASE       (KE_USER_BOOTSTRAP_CONST_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
+#define KE_USER_BOOTSTRAP_STACK_BASE             (KE_USER_BOOTSTRAP_STACK_GUARD_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
+#define KE_USER_BOOTSTRAP_STACK_TOP              (KE_USER_BOOTSTRAP_STACK_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
+#define KE_USER_BOOTSTRAP_STACK_PAGE_COUNT       1ULL
+#define KE_USER_BOOTSTRAP_STACK_GUARD_PAGE_COUNT 1ULL
+#define KE_USER_BOOTSTRAP_STACK_MAILBOX_OFFSET   0ULL
+#define KE_USER_BOOTSTRAP_STACK_MAILBOX_ADDRESS  (KE_USER_BOOTSTRAP_STACK_BASE + KE_USER_BOOTSTRAP_STACK_MAILBOX_OFFSET)
+#define KE_USER_BOOTSTRAP_P1_MAILBOX_CLOSED      0U
+#define KE_USER_BOOTSTRAP_P1_MAILBOX_GATE_OPEN   0x31504741U
+
+/*
+ * Bootstrap raw syscall ABI:
+ * - Entry is a synchronous int 0x80 trap.
+ * - RAX carries the raw syscall number on entry and the return value on exit.
+ * - RDI, RSI, and RDX carry the first three bootstrap arguments.
+ *
+ * The SYS_RAW_* namespace is intentionally scoped to bring-up only. Future
+ * handle-oriented SYS_* services may use different numbers and semantics.
+ */
+#define KE_USER_BOOTSTRAP_SYSCALL_VECTOR             0x80U
+#define KE_USER_BOOTSTRAP_SYS_RAW_WRITE_MAX_LENGTH   256U
+
+#define SYS_RAW_INVALID                              0U
+#define SYS_RAW_WRITE                                1U
+#define SYS_RAW_EXIT                                 2U
+
+/*
+ * Bootstrap raw write keeps both rejection and success paths on the same
+ * helper family in ke/user_bootstrap_syscall.c:
+ * - validate the fixed bootstrap user window range
+ * - validate that covered pages remain user accessible
+ * - bounded copy-in into a kernel scratch buffer
+ *
+ * Stable user_hello evidence-chain anchors then record P1 milestones first,
+ * followed by raw-write rejection/success and raw-exit handoff.
+ */
+#define KE_USER_BOOTSTRAP_LOG_ENTER_USER_MODE          "[USERBOOT] enter user mode"
+#define KE_USER_BOOTSTRAP_LOG_P1_FIRST_ENTRY           KE_USER_BOOTSTRAP_LOG_ENTER_USER_MODE
+#define KE_USER_BOOTSTRAP_LOG_TIMER_FROM_USER_FORMAT   "[USERBOOT] timer from user #%u"
+#define KE_USER_BOOTSTRAP_LOG_P1_GATE_ARMED            "[USERBOOT] P1 gate armed"
+#define KE_USER_BOOTSTRAP_LOG_HELLO                    "[USERBOOT] hello"
+#define KE_USER_BOOTSTRAP_LOG_INVALID_RAW_WRITE        "[USERBOOT] invalid raw write rejected"
+#define KE_USER_BOOTSTRAP_LOG_HELLO_WRITE_SUCCEEDED    "[USERBOOT] hello write succeeds"
+#define KE_USER_BOOTSTRAP_LOG_SYS_RAW_EXIT             "[USERBOOT] SYS_RAW_EXIT"
+#define KE_USER_BOOTSTRAP_LOG_INVALID_SYSCALL          "[USERBOOT] invalid raw syscall"
+#define KE_USER_BOOTSTRAP_LOG_INVALID_USER_BUFFER      "[USERBOOT] invalid user buffer"
+#define KE_USER_BOOTSTRAP_LOG_TEARDOWN_FAILED          "[USERBOOT] bootstrap teardown failed"
+#define KE_USER_BOOTSTRAP_LOG_TEARDOWN_COMPLETE        "[USERBOOT] bootstrap teardown complete"
+#define KE_USER_BOOTSTRAP_LOG_FALLBACK_RECLAIM         "[USERBOOT] fallback staging reclaim in finalizer"
+#define KE_USER_BOOTSTRAP_LOG_THREAD_TERMINATED_FORMAT "[SCHED] Thread %u terminated"
+#define KE_USER_BOOTSTRAP_LOG_IDLE_REAPER              "[USERBOOT] idle/reaper reclaimed user_hello thread"

--- a/src/include/kernel/ex/ex_bootstrap_adapter.h
+++ b/src/include/kernel/ex/ex_bootstrap_adapter.h
@@ -2,7 +2,7 @@
  * HimuOperatingSystem
  *
  * File: ex/ex_bootstrap_adapter.h
- * Description: Thin Ex bootstrap adapter - ownership and callback bridge.
+ * Description: Ex bootstrap callback bridge used by the runtime facade.
  * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
  */
 
@@ -11,6 +11,7 @@
 #include <_hobase.h>
 
 struct KTHREAD;
+struct KE_USER_BOOTSTRAP_STAGING;
 
 /**
  * Initialize the Ex bootstrap adapter subsystem.
@@ -19,17 +20,17 @@ struct KTHREAD;
 HO_KERNEL_API HO_STATUS ExBootstrapAdapterInit(void);
 
 /**
- * Lazily wrap the current thread's existing KTHREAD + staging in Ex objects
- * (EX_PROCESS / EX_THREAD). Idempotent - second call for the same thread
- * is a no-op returning EC_SUCCESS.
- * Called by Phase 3 enter callback.
+ * Validate that the current bootstrap thread already has Ex-owned wrapper
+ * state registered. Idempotent - second call for the same thread is a no-op
+ * returning EC_SUCCESS.
+ * Called by the registered bootstrap enter callback.
  */
 HO_KERNEL_API HO_STATUS ExBootstrapAdapterWrapThread(struct KTHREAD *thread);
 
 /**
  * Finalize the Ex ownership for a terminated bootstrap thread: destroy the
  * staging through ExProcess ownership, then free Ex objects.
- * Called by Phase 3 finalize callback; replaces direct KeUserBootstrapDestroyStaging.
+ * Called by the registered bootstrap finalize callback.
  * Returns EC_SUCCESS if the thread had no Ex wrapper (non-bootstrap path).
  */
 HO_KERNEL_API HO_STATUS ExBootstrapAdapterFinalizeThread(struct KTHREAD *thread);
@@ -39,3 +40,18 @@ HO_KERNEL_API HO_STATUS ExBootstrapAdapterFinalizeThread(struct KTHREAD *thread)
  * Returns TRUE if the adapter owns an EX_THREAD for this KTHREAD.
  */
 HO_KERNEL_API BOOL ExBootstrapAdapterHasWrapper(const struct KTHREAD *thread);
+
+/**
+ * Query the Ex-owned bootstrap staging associated with a KTHREAD.
+ * Returns NULL if the thread is not owned by the Ex bootstrap runtime or if
+ * the clean raw-exit path has already consumed the staging.
+ */
+HO_KERNEL_API struct KE_USER_BOOTSTRAP_STAGING *ExBootstrapAdapterQueryThreadStaging(const struct KTHREAD *thread);
+
+/**
+ * Destroy bootstrap staging for a clean SYS_RAW_EXIT handoff.
+ * On success the staging is consumed but the minimal Ex wrapper remains until
+ * finalizer/reaper release the bootstrap thread identity.
+ * On failure both staging ownership and Ex wrapper state are cleared.
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS ExBootstrapAdapterHandleRawExit(struct KTHREAD *thread);

--- a/src/include/kernel/ex/ex_bootstrap_adapter.h
+++ b/src/include/kernel/ex/ex_bootstrap_adapter.h
@@ -1,0 +1,41 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ex/ex_bootstrap_adapter.h
+ * Description: Thin Ex bootstrap adapter - ownership and callback bridge.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <_hobase.h>
+
+struct KTHREAD;
+
+/**
+ * Initialize the Ex bootstrap adapter subsystem.
+ * Must be called before any bootstrap user thread is scheduled.
+ */
+HO_KERNEL_API HO_STATUS ExBootstrapAdapterInit(void);
+
+/**
+ * Lazily wrap the current thread's existing KTHREAD + staging in Ex objects
+ * (EX_PROCESS / EX_THREAD). Idempotent - second call for the same thread
+ * is a no-op returning EC_SUCCESS.
+ * Called by Phase 3 enter callback.
+ */
+HO_KERNEL_API HO_STATUS ExBootstrapAdapterWrapThread(struct KTHREAD *thread);
+
+/**
+ * Finalize the Ex ownership for a terminated bootstrap thread: destroy the
+ * staging through ExProcess ownership, then free Ex objects.
+ * Called by Phase 3 finalize callback; replaces direct KeUserBootstrapDestroyStaging.
+ * Returns EC_SUCCESS if the thread had no Ex wrapper (non-bootstrap path).
+ */
+HO_KERNEL_API HO_STATUS ExBootstrapAdapterFinalizeThread(struct KTHREAD *thread);
+
+/**
+ * Query whether a KTHREAD currently has an Ex bootstrap wrapper.
+ * Returns TRUE if the adapter owns an EX_THREAD for this KTHREAD.
+ */
+HO_KERNEL_API BOOL ExBootstrapAdapterHasWrapper(const struct KTHREAD *thread);

--- a/src/include/kernel/ex/ex_process.h
+++ b/src/include/kernel/ex/ex_process.h
@@ -1,0 +1,11 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ex/ex_process.h
+ * Description: Forward declaration for the thin Ex bootstrap process owner.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+typedef struct EX_PROCESS EX_PROCESS;

--- a/src/include/kernel/ex/ex_process.h
+++ b/src/include/kernel/ex/ex_process.h
@@ -2,10 +2,22 @@
  * HimuOperatingSystem
  *
  * File: ex/ex_process.h
- * Description: Forward declaration for the thin Ex bootstrap process owner.
+ * Description: Bootstrap-scoped Ex process wrapper and create parameters.
  * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
  */
 
 #pragma once
 
+#include <_hobase.h>
+
+/* Opaque owning handle for bootstrap process staging until transferred. */
 typedef struct EX_PROCESS EX_PROCESS;
+
+typedef struct EX_BOOTSTRAP_PROCESS_CREATE_PARAMS
+{
+	const void *CodeBytes;
+	uint64_t CodeLength;
+	uint64_t EntryOffset;
+	const void *ConstBytes;
+	uint64_t ConstLength;
+} EX_BOOTSTRAP_PROCESS_CREATE_PARAMS;

--- a/src/include/kernel/ex/ex_thread.h
+++ b/src/include/kernel/ex/ex_thread.h
@@ -1,0 +1,11 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ex/ex_thread.h
+ * Description: Forward declaration for the thin Ex bootstrap thread owner.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+typedef struct EX_THREAD EX_THREAD;

--- a/src/include/kernel/ex/ex_thread.h
+++ b/src/include/kernel/ex/ex_thread.h
@@ -2,10 +2,21 @@
  * HimuOperatingSystem
  *
  * File: ex/ex_thread.h
- * Description: Forward declaration for the thin Ex bootstrap thread owner.
+ * Description: Bootstrap-scoped Ex thread wrapper and create parameters.
  * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
  */
 
 #pragma once
 
+#include <_hobase.h>
+
+/* Opaque owning handle for a bootstrap thread before runtime takeover. */
 typedef struct EX_THREAD EX_THREAD;
+
+typedef void (*EX_BOOTSTRAP_THREAD_ENTRY)(void *arg);
+
+typedef struct EX_BOOTSTRAP_THREAD_CREATE_PARAMS
+{
+	EX_BOOTSTRAP_THREAD_ENTRY EntryPoint;
+	void *EntryArg;
+} EX_BOOTSTRAP_THREAD_CREATE_PARAMS;

--- a/src/include/kernel/ke/bootstrap_callbacks.h
+++ b/src/include/kernel/ke/bootstrap_callbacks.h
@@ -1,0 +1,45 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/bootstrap_callbacks.h
+ * Description: Ke-side bootstrap callback registration contract.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <_hobase.h>
+
+struct KTHREAD;
+
+/**
+ * Bootstrap enter callback - called from thread trampoline when the thread
+ * has a non-NULL UserBootstrapContext. Must not return.
+ */
+typedef void (*KE_BOOTSTRAP_ENTER_FN)(struct KTHREAD *thread) HO_NORETURN;
+
+/**
+ * Bootstrap finalize callback - called from thread finalizer when a
+ * terminated thread may hold bootstrap resources.
+ * Return EC_SUCCESS if nothing needs to be cleaned; error propagates.
+ */
+typedef HO_STATUS (*KE_BOOTSTRAP_FINALIZE_FN)(struct KTHREAD *thread);
+
+/**
+ * Bootstrap timer observe callback - called from the timer ISR when the
+ * interrupted context was in user mode (CPL 3).
+ */
+typedef void (*KE_BOOTSTRAP_TIMER_OBSERVE_FN)(struct KTHREAD *thread);
+
+/**
+ * Register bootstrap callbacks. All three must be non-NULL.
+ * Must be called before any bootstrap user thread is scheduled.
+ * May only be called once.
+ */
+HO_KERNEL_API HO_STATUS KeRegisterBootstrapCallbacks(KE_BOOTSTRAP_ENTER_FN enterFn,
+                                                     KE_BOOTSTRAP_FINALIZE_FN finalizeFn,
+                                                     KE_BOOTSTRAP_TIMER_OBSERVE_FN timerObserveFn);
+
+KE_BOOTSTRAP_ENTER_FN KiGetBootstrapEnterCallback(void);
+KE_BOOTSTRAP_FINALIZE_FN KiGetBootstrapFinalizeCallback(void);
+KE_BOOTSTRAP_TIMER_OBSERVE_FN KiGetBootstrapTimerObserveCallback(void);

--- a/src/include/kernel/ke/bootstrap_callbacks.h
+++ b/src/include/kernel/ke/bootstrap_callbacks.h
@@ -14,9 +14,15 @@ struct KTHREAD;
 
 /**
  * Bootstrap enter callback - called from thread trampoline when the thread
- * has a non-NULL UserBootstrapContext. Must not return.
+ * is owned by the bootstrap runtime. Must not return.
  */
 typedef void (*KE_BOOTSTRAP_ENTER_FN)(struct KTHREAD *thread) HO_NORETURN;
+
+/**
+ * Bootstrap thread ownership query callback - called by Ke-side scheduling
+ * paths to determine whether a thread belongs to the bootstrap runtime.
+ */
+typedef BOOL (*KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN)(const struct KTHREAD *thread);
 
 /**
  * Bootstrap finalize callback - called from thread finalizer when a
@@ -32,14 +38,16 @@ typedef HO_STATUS (*KE_BOOTSTRAP_FINALIZE_FN)(struct KTHREAD *thread);
 typedef void (*KE_BOOTSTRAP_TIMER_OBSERVE_FN)(struct KTHREAD *thread);
 
 /**
- * Register bootstrap callbacks. All three must be non-NULL.
+ * Register bootstrap callbacks. All four must be non-NULL.
  * Must be called before any bootstrap user thread is scheduled.
  * May only be called once.
  */
 HO_KERNEL_API HO_STATUS KeRegisterBootstrapCallbacks(KE_BOOTSTRAP_ENTER_FN enterFn,
+                                                     KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN threadOwnershipQueryFn,
                                                      KE_BOOTSTRAP_FINALIZE_FN finalizeFn,
                                                      KE_BOOTSTRAP_TIMER_OBSERVE_FN timerObserveFn);
 
 KE_BOOTSTRAP_ENTER_FN KiGetBootstrapEnterCallback(void);
+KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN KiGetBootstrapThreadOwnershipQueryCallback(void);
 KE_BOOTSTRAP_FINALIZE_FN KiGetBootstrapFinalizeCallback(void);
 KE_BOOTSTRAP_TIMER_OBSERVE_FN KiGetBootstrapTimerObserveCallback(void);

--- a/src/include/kernel/ke/kthread.h
+++ b/src/include/kernel/ke/kthread.h
@@ -65,14 +65,11 @@ typedef struct KTHREAD_CONTEXT
     uint64_t RIP; // offset 56  (informational; actual RIP is on stack for KiSwitchContext)
 } KTHREAD_CONTEXT;
 
-struct KE_USER_BOOTSTRAP_STAGING;
-
 // ─────────────────────────────────────────────────────────────
 // KTHREAD structure
 // ─────────────────────────────────────────────────────────────
 
-#define KTHREAD_FLAG_IDLE           (1U << 0)
-#define KTHREAD_FLAG_BOOTSTRAP_USER (1U << 1)
+#define KTHREAD_FLAG_IDLE (1U << 0)
 
 typedef struct KTHREAD
 {
@@ -101,7 +98,6 @@ typedef struct KTHREAD
     KTHREAD_ENTRY EntryPoint;
     void *EntryArg;
     uint32_t Flags;
-    struct KE_USER_BOOTSTRAP_STAGING *UserBootstrapContext;
 } KTHREAD;
 
 // ─────────────────────────────────────────────────────────────

--- a/src/include/kernel/ke/user_bootstrap.h
+++ b/src/include/kernel/ke/user_bootstrap.h
@@ -2,81 +2,16 @@
  * HimuOperatingSystem
  *
  * File: ke/user_bootstrap.h
- * Description: Minimal bootstrap-only user-mode ABI and log anchors.
+ * Description: Ke-internal bootstrap staging and first-entry helpers.
  * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
  */
 
 #pragma once
 
 #include <_hobase.h>
+
+#include <kernel/ex/ex_bootstrap_abi.h>
 #include <kernel/ke/kthread.h>
-
-/*
- * The fixed low-half user window below is a staging/bootstrap model only.
- * It reuses the shared imported kernel root for the first user-mode slice and
- * must not be treated as the long-term per-process address-space contract.
- * Keep it above the boot-time low 2GB identity import so hole validation sees
- * an unmapped slot in the shared root.
- */
-#define KE_USER_BOOTSTRAP_PAGE_SIZE              0x1000ULL
-#define KE_USER_BOOTSTRAP_WINDOW_BASE            0x0000000080000000ULL
-#define KE_USER_BOOTSTRAP_WINDOW_PAGE_COUNT      4ULL
-#define KE_USER_BOOTSTRAP_WINDOW_END_EXCLUSIVE   (KE_USER_BOOTSTRAP_WINDOW_BASE +                     \
-                                                  (KE_USER_BOOTSTRAP_WINDOW_PAGE_COUNT *              \
-                                                   KE_USER_BOOTSTRAP_PAGE_SIZE))
-#define KE_USER_BOOTSTRAP_CODE_BASE              KE_USER_BOOTSTRAP_WINDOW_BASE
-#define KE_USER_BOOTSTRAP_CONST_BASE             (KE_USER_BOOTSTRAP_CODE_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
-#define KE_USER_BOOTSTRAP_STACK_GUARD_BASE       (KE_USER_BOOTSTRAP_CONST_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
-#define KE_USER_BOOTSTRAP_STACK_BASE             (KE_USER_BOOTSTRAP_STACK_GUARD_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
-#define KE_USER_BOOTSTRAP_STACK_TOP              (KE_USER_BOOTSTRAP_STACK_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
-#define KE_USER_BOOTSTRAP_STACK_PAGE_COUNT       1ULL
-#define KE_USER_BOOTSTRAP_STACK_GUARD_PAGE_COUNT 1ULL
-#define KE_USER_BOOTSTRAP_STACK_MAILBOX_OFFSET   0ULL
-#define KE_USER_BOOTSTRAP_STACK_MAILBOX_ADDRESS  (KE_USER_BOOTSTRAP_STACK_BASE + KE_USER_BOOTSTRAP_STACK_MAILBOX_OFFSET)
-#define KE_USER_BOOTSTRAP_P1_MAILBOX_CLOSED      0U
-#define KE_USER_BOOTSTRAP_P1_MAILBOX_GATE_OPEN   0x31504741U
-
-/*
- * Bootstrap raw syscall ABI:
- * - Entry is a synchronous int 0x80 trap.
- * - RAX carries the raw syscall number on entry and the return value on exit.
- * - RDI, RSI, and RDX carry the first three bootstrap arguments.
- *
- * The SYS_RAW_* namespace is intentionally scoped to bring-up only. Future
- * handle-oriented SYS_* services may use different numbers and semantics.
- */
-#define KE_USER_BOOTSTRAP_SYSCALL_VECTOR             0x80U
-#define KE_USER_BOOTSTRAP_SYS_RAW_WRITE_MAX_LENGTH   256U
-
-#define SYS_RAW_INVALID                              0U
-#define SYS_RAW_WRITE                                1U
-#define SYS_RAW_EXIT                                 2U
-
-/*
- * Bootstrap raw write keeps both rejection and success paths on the same
- * helper family in ke/user_bootstrap_syscall.c:
- * - validate the fixed bootstrap user window range
- * - validate that covered pages remain user accessible
- * - bounded copy-in into a kernel scratch buffer
- *
- * Stable user_hello evidence-chain anchors then record P1 milestones first,
- * followed by raw-write rejection/success and raw-exit handoff.
- */
-#define KE_USER_BOOTSTRAP_LOG_ENTER_USER_MODE          "[USERBOOT] enter user mode"
-#define KE_USER_BOOTSTRAP_LOG_P1_FIRST_ENTRY           KE_USER_BOOTSTRAP_LOG_ENTER_USER_MODE
-#define KE_USER_BOOTSTRAP_LOG_TIMER_FROM_USER_FORMAT   "[USERBOOT] timer from user #%u"
-#define KE_USER_BOOTSTRAP_LOG_P1_GATE_ARMED            "[USERBOOT] P1 gate armed"
-#define KE_USER_BOOTSTRAP_LOG_HELLO                    "[USERBOOT] hello"
-#define KE_USER_BOOTSTRAP_LOG_INVALID_RAW_WRITE        "[USERBOOT] invalid raw write rejected"
-#define KE_USER_BOOTSTRAP_LOG_HELLO_WRITE_SUCCEEDED    "[USERBOOT] hello write succeeds"
-#define KE_USER_BOOTSTRAP_LOG_SYS_RAW_EXIT             "[USERBOOT] SYS_RAW_EXIT"
-#define KE_USER_BOOTSTRAP_LOG_INVALID_SYSCALL          "[USERBOOT] invalid raw syscall"
-#define KE_USER_BOOTSTRAP_LOG_INVALID_USER_BUFFER      "[USERBOOT] invalid user buffer"
-#define KE_USER_BOOTSTRAP_LOG_TEARDOWN_FAILED          "[USERBOOT] bootstrap teardown failed"
-#define KE_USER_BOOTSTRAP_LOG_TEARDOWN_COMPLETE        "[USERBOOT] bootstrap teardown complete"
-#define KE_USER_BOOTSTRAP_LOG_FALLBACK_RECLAIM         "[USERBOOT] fallback staging reclaim in finalizer"
-#define KE_USER_BOOTSTRAP_LOG_THREAD_TERMINATED_FORMAT "[SCHED] Thread %u terminated"
-#define KE_USER_BOOTSTRAP_LOG_IDLE_REAPER              "[USERBOOT] idle/reaper reclaimed user_hello thread"
 
 typedef struct KE_USER_BOOTSTRAP_STAGING KE_USER_BOOTSTRAP_STAGING;
 

--- a/src/kernel/demo/demo_internal.h
+++ b/src/kernel/demo/demo_internal.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <kernel/demo.h>
+#include <kernel/ex/ex_bootstrap_abi.h>
 #include <kernel/hodbg.h>
 #include <kernel/ke/scheduler.h>
 #include <kernel/ke/kthread.h>
@@ -18,7 +19,6 @@
 #include <kernel/ke/event.h>
 #include <kernel/ke/mutex.h>
 #include <kernel/ke/semaphore.h>
-#include <kernel/ke/user_bootstrap.h>
 
 #define HO_DEMO_TEST_NONE              0
 #define HO_DEMO_TEST_SCHEDULE          1

--- a/src/kernel/demo/user_hello.c
+++ b/src/kernel/demo/user_hello.c
@@ -20,6 +20,8 @@
 
 #include "demo_internal.h"
 
+#include <kernel/ex/ex_bootstrap.h>
+
 #define KI_U32_BYTE(value, shift) ((uint8_t)((((uint32_t)(value)) >> (shift)) & 0xFFU))
 #define KI_U32_LE_BYTES(value)    KI_U32_BYTE((value), 0), KI_U32_BYTE((value), 8), KI_U32_BYTE((value), 16), \
                                  KI_U32_BYTE((value), 24)
@@ -80,31 +82,29 @@ KiUnexpectedUserHelloKernelEntry(void *arg)
 void
 RunUserHelloDemo(void)
 {
-    KE_USER_BOOTSTRAP_CREATE_PARAMS createParams = {
+    EX_BOOTSTRAP_PROCESS_CREATE_PARAMS createParams = {
         .CodeBytes = gKiUserHelloCodeBytes,
         .CodeLength = sizeof(gKiUserHelloCodeBytes),
         .EntryOffset = KI_USER_HELLO_PAYLOAD_ENTRY_OFFSET,
         .ConstBytes = gKiUserHelloConstBytes,
         .ConstLength = KI_USER_HELLO_PAYLOAD_HELLO_LENGTH,
     };
-    KE_USER_BOOTSTRAP_STAGING *staging = NULL;
-    KTHREAD *thread = NULL;
+    EX_BOOTSTRAP_THREAD_CREATE_PARAMS threadParams = {
+        .EntryPoint = KiUnexpectedUserHelloKernelEntry,
+        .EntryArg = NULL,
+    };
+    EX_PROCESS *process = NULL;
+    EX_THREAD *thread = NULL;
 
-    HO_STATUS status = KeUserBootstrapCreateStaging(&createParams, &staging);
+    HO_STATUS status = ExBootstrapCreateProcess(&createParams, &process);
     if (status != EC_SUCCESS)
         HO_KPANIC(status, "Failed to create staged user_hello payload");
 
-    status = KeThreadCreate(&thread, KiUnexpectedUserHelloKernelEntry, NULL);
+    status = ExBootstrapCreateThread(&process, &threadParams, &thread);
     if (status != EC_SUCCESS)
         HO_KPANIC(status, "Failed to create user_hello bootstrap thread");
 
-    thread->Flags |= KTHREAD_FLAG_BOOTSTRAP_USER;
-
-    status = KeUserBootstrapAttachThread(thread, staging);
-    if (status != EC_SUCCESS)
-        HO_KPANIC(status, "Failed to attach staged user_hello payload to bootstrap thread");
-
-    status = KeThreadStart(thread);
+    status = ExBootstrapStartThread(&thread);
     if (status != EC_SUCCESS)
         HO_KPANIC(status, "Failed to start user_hello bootstrap thread");
 }

--- a/src/kernel/demo/user_hello.c
+++ b/src/kernel/demo/user_hello.c
@@ -9,6 +9,15 @@
  * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
  */
 
+/*
+ * Refactor anchor: keep the user_hello clean-pass evidence chain fixed as
+ * first entry, timer round-trip, rejected raw write, hello write,
+ * SYS_RAW_EXIT, bootstrap teardown complete, and idle/reaper reclaim.
+ * This change only permits boundary refactoring around ownership and
+ * registration seams for bootstrap user support.
+ * It must not change the profile's logs, ordering contract, or pass/fail behavior.
+ */
+
 #include "demo_internal.h"
 
 #define KI_U32_BYTE(value, shift) ((uint8_t)((((uint32_t)(value)) >> (shift)) & 0xFFU))

--- a/src/kernel/ex/ex_bootstrap.c
+++ b/src/kernel/ex/ex_bootstrap.c
@@ -1,0 +1,224 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ex/ex_bootstrap.c
+ * Description: Ex-owned bootstrap runtime init and launch facade.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#include <kernel/ex/ex_bootstrap.h>
+
+#include "ex_bootstrap_internal.h"
+
+#include <kernel/ex/ex_bootstrap_adapter.h>
+#include <kernel/ke/kthread.h>
+#include <kernel/ke/mm.h>
+#include <kernel/ke/scheduler.h>
+#include <kernel/ke/user_bootstrap.h>
+
+EX_PROCESS *gExBootstrapProcess = NULL;
+EX_THREAD *gExBootstrapThread = NULL;
+
+static HO_STATUS
+KiDestroyNewThread(KTHREAD *thread)
+{
+    if (thread == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if ((thread->Flags & KTHREAD_FLAG_IDLE) != 0 || thread->State != KTHREAD_STATE_NEW)
+        return EC_INVALID_STATE;
+
+    if (thread->StackOwnedByKva)
+    {
+        HO_STATUS status = KeKvaReleaseRangeHandle(&thread->StackRange);
+        if (status != EC_SUCCESS)
+            return status;
+    }
+
+    KePoolFree(&gKThreadPool, thread);
+    return EC_SUCCESS;
+}
+
+HO_STATUS
+ExBootstrapInit(void)
+{
+    HO_STATUS status = KeUserBootstrapRawSyscallInit();
+    if (status != EC_SUCCESS)
+        return status;
+
+    return ExBootstrapAdapterInit();
+}
+
+HO_STATUS
+ExBootstrapCreateProcess(const EX_BOOTSTRAP_PROCESS_CREATE_PARAMS *params, EX_PROCESS **outProcess)
+{
+    KE_USER_BOOTSTRAP_STAGING *staging = NULL;
+    EX_PROCESS *process = NULL;
+    KE_USER_BOOTSTRAP_CREATE_PARAMS keParams = {0};
+
+    if (outProcess == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    *outProcess = NULL;
+
+    if (params == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    keParams.CodeBytes = params->CodeBytes;
+    keParams.CodeLength = params->CodeLength;
+    keParams.EntryOffset = params->EntryOffset;
+    keParams.ConstBytes = params->ConstBytes;
+    keParams.ConstLength = params->ConstLength;
+
+    HO_STATUS status = KeUserBootstrapCreateStaging(&keParams, &staging);
+    if (status != EC_SUCCESS)
+        return status;
+
+    process = (EX_PROCESS *)kzalloc(sizeof(*process));
+    if (process == NULL)
+    {
+        status = KeUserBootstrapDestroyStaging(staging);
+        return status == EC_SUCCESS ? EC_OUT_OF_RESOURCE : status;
+    }
+
+    process->Staging = staging;
+    *outProcess = process;
+    return EC_SUCCESS;
+}
+
+HO_STATUS
+ExBootstrapDestroyProcess(EX_PROCESS *process)
+{
+    HO_STATUS status = EC_SUCCESS;
+
+    if (process == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (process == gExBootstrapProcess)
+        return EC_INVALID_STATE;
+
+    if (process->Staging != NULL)
+    {
+        status = KeUserBootstrapDestroyStaging(process->Staging);
+
+        /* Destroy consumes the staging object even when teardown reports an error. */
+        process->Staging = NULL;
+    }
+
+    kfree(process);
+    return status;
+}
+
+HO_STATUS
+ExBootstrapCreateThread(EX_PROCESS **processHandle,
+                        const EX_BOOTSTRAP_THREAD_CREATE_PARAMS *params,
+                        EX_THREAD **outThread)
+{
+    EX_PROCESS *process = NULL;
+    EX_THREAD *thread = NULL;
+    KTHREAD *kernelThread = NULL;
+
+    if (processHandle == NULL || outThread == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    *outThread = NULL;
+    process = *processHandle;
+
+    if (process == NULL || params == NULL || params->EntryPoint == NULL || process->Staging == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (gExBootstrapProcess != NULL || gExBootstrapThread != NULL)
+        return EC_INVALID_STATE;
+
+    thread = (EX_THREAD *)kzalloc(sizeof(*thread));
+    if (thread == NULL)
+        return EC_OUT_OF_RESOURCE;
+
+    HO_STATUS status = KeThreadCreate(&kernelThread, (KTHREAD_ENTRY)params->EntryPoint, params->EntryArg);
+    if (status != EC_SUCCESS)
+    {
+        kfree(thread);
+        return status;
+    }
+
+    status = KeUserBootstrapAttachThread(kernelThread, process->Staging);
+    if (status != EC_SUCCESS)
+    {
+        HO_STATUS destroyStatus = KiDestroyNewThread(kernelThread);
+        kfree(thread);
+        return destroyStatus == EC_SUCCESS ? status : destroyStatus;
+    }
+
+    thread->Thread = kernelThread;
+    thread->Process = process;
+
+    gExBootstrapProcess = process;
+    gExBootstrapThread = thread;
+
+    *outThread = thread;
+    *processHandle = NULL;
+    return EC_SUCCESS;
+}
+
+HO_STATUS
+ExBootstrapStartThread(EX_THREAD **threadHandle)
+{
+    EX_THREAD *thread = NULL;
+
+    if (threadHandle == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    thread = *threadHandle;
+
+    if (thread == NULL || thread->Thread == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    HO_STATUS status = KeThreadStart(thread->Thread);
+    if (status != EC_SUCCESS)
+        return status;
+
+    *threadHandle = NULL;
+    return EC_SUCCESS;
+}
+
+HO_STATUS
+ExBootstrapTeardownThread(EX_THREAD *thread)
+{
+    EX_PROCESS *process = NULL;
+    HO_STATUS firstError = EC_SUCCESS;
+
+    if (thread == NULL || thread->Thread == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (gExBootstrapThread != thread)
+        return EC_INVALID_STATE;
+
+    if (thread->Thread->State != KTHREAD_STATE_NEW)
+        return EC_INVALID_STATE;
+
+    process = thread->Process;
+
+    if (process != NULL && process->Staging != NULL)
+    {
+        firstError = KeUserBootstrapDestroyStaging(process->Staging);
+
+        /* Destroy consumes the staging object even when teardown reports an error. */
+        process->Staging = NULL;
+    }
+
+    HO_STATUS threadStatus = KiDestroyNewThread(thread->Thread);
+    if (firstError == EC_SUCCESS)
+        firstError = threadStatus;
+
+    gExBootstrapThread = NULL;
+    gExBootstrapProcess = NULL;
+
+    thread->Thread = NULL;
+    thread->Process = NULL;
+    kfree(thread);
+
+    if (process != NULL)
+        kfree(process);
+
+    return firstError;
+}

--- a/src/kernel/ex/ex_bootstrap_adapter.c
+++ b/src/kernel/ex/ex_bootstrap_adapter.c
@@ -2,33 +2,20 @@
  * HimuOperatingSystem
  *
  * File: ex/ex_bootstrap_adapter.c
- * Description: Thin Ex bootstrap adapter ownership layer.
+ * Description: Thin Ex bootstrap adapter callback bridge.
  * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
  */
 
+#include "ex_bootstrap_internal.h"
+
 #include <kernel/ex/ex_bootstrap_adapter.h>
-#include <kernel/ex/ex_process.h>
-#include <kernel/ex/ex_thread.h>
 #include <kernel/ke/bootstrap_callbacks.h>
 #include <kernel/ke/kthread.h>
 #include <kernel/ke/mm.h>
 #include <kernel/ke/user_bootstrap.h>
 #include <kernel/hodbg.h>
 
-struct EX_PROCESS
-{
-    KE_USER_BOOTSTRAP_STAGING *Staging;
-};
-
-struct EX_THREAD
-{
-    KTHREAD *Thread;
-    EX_PROCESS *Process;
-};
-
-/* Only one bootstrap process/thread wrapper may exist at a time. */
-static EX_PROCESS *gBootstrapProcess = NULL;
-static EX_THREAD *gBootstrapThread = NULL;
+static void KiDestroyBootstrapWrapperObjects(void);
 
 static HO_NORETURN void
 ExBootstrapEnterCallback(KTHREAD *thread)
@@ -42,10 +29,16 @@ ExBootstrapEnterCallback(KTHREAD *thread)
     KeUserBootstrapEnterCurrentThread();
 }
 
+static BOOL
+ExBootstrapThreadOwnershipQueryCallback(const KTHREAD *thread)
+{
+    return ExBootstrapAdapterHasWrapper(thread);
+}
+
 static HO_STATUS
 ExBootstrapFinalizeCallback(KTHREAD *thread)
 {
-    if (thread != NULL && thread->UserBootstrapContext != NULL)
+    if (thread != NULL && ExBootstrapAdapterQueryThreadStaging(thread) != NULL)
     {
         klog(KLOG_LEVEL_WARNING, "[USERBOOT] fallback staging reclaim in finalizer thread=%u\n", thread->ThreadId);
     }
@@ -64,6 +57,7 @@ HO_STATUS
 ExBootstrapAdapterInit(void)
 {
     return KeRegisterBootstrapCallbacks(ExBootstrapEnterCallback,
+                                        ExBootstrapThreadOwnershipQueryCallback,
                                         ExBootstrapFinalizeCallback,
                                         ExBootstrapTimerObserveCallback);
 }
@@ -71,36 +65,15 @@ ExBootstrapAdapterInit(void)
 HO_STATUS
 ExBootstrapAdapterWrapThread(KTHREAD *thread)
 {
-    EX_PROCESS *process = NULL;
-    EX_THREAD *exThread = NULL;
-
-    if (gBootstrapThread != NULL && gBootstrapThread->Thread == thread)
-        return EC_SUCCESS;
-
-    if (gBootstrapThread != NULL)
-        return EC_INVALID_STATE;
-
-    if (thread == NULL || thread->UserBootstrapContext == NULL)
+    if (thread == NULL)
         return EC_ILLEGAL_ARGUMENT;
 
-    process = (EX_PROCESS *)kzalloc(sizeof(*process));
-    if (process == NULL)
-        return EC_OUT_OF_RESOURCE;
+    if (gExBootstrapThread == NULL || gExBootstrapThread->Thread != thread)
+        return EC_INVALID_STATE;
 
-    process->Staging = thread->UserBootstrapContext;
+    if (gExBootstrapThread->Process == NULL || gExBootstrapThread->Process->Staging == NULL)
+        return EC_INVALID_STATE;
 
-    exThread = (EX_THREAD *)kzalloc(sizeof(*exThread));
-    if (exThread == NULL)
-    {
-        kfree(process);
-        return EC_OUT_OF_RESOURCE;
-    }
-
-    exThread->Thread = thread;
-    exThread->Process = process;
-
-    gBootstrapProcess = process;
-    gBootstrapThread = exThread;
     return EC_SUCCESS;
 }
 
@@ -110,33 +83,88 @@ ExBootstrapAdapterFinalizeThread(KTHREAD *thread)
     EX_PROCESS *process = NULL;
     HO_STATUS status = EC_SUCCESS;
 
-    if (gBootstrapThread == NULL || gBootstrapThread->Thread != thread)
+    if (gExBootstrapThread == NULL || gExBootstrapThread->Thread != thread)
         return EC_SUCCESS;
 
-    process = gBootstrapThread->Process;
+    process = gExBootstrapThread->Process;
 
     if (process != NULL && process->Staging != NULL)
     {
-        if (thread->UserBootstrapContext != NULL)
-        {
-            HO_KASSERT(process->Staging == thread->UserBootstrapContext, EC_INVALID_STATE);
-            status = KeUserBootstrapDestroyStaging(process->Staging);
-        }
+        status = KeUserBootstrapDestroyStaging(process->Staging);
 
         /* Destroy consumes the staging object even when teardown reports an error. */
         process->Staging = NULL;
     }
 
-    kfree(gBootstrapThread);
-    gBootstrapThread = NULL;
-
-    kfree(gBootstrapProcess);
-    gBootstrapProcess = NULL;
+    KiDestroyBootstrapWrapperObjects();
     return status;
 }
 
 BOOL
 ExBootstrapAdapterHasWrapper(const KTHREAD *thread)
 {
-    return gBootstrapThread != NULL && gBootstrapThread->Thread == thread;
+    return gExBootstrapThread != NULL && gExBootstrapThread->Thread == thread;
+}
+
+struct KE_USER_BOOTSTRAP_STAGING *
+ExBootstrapAdapterQueryThreadStaging(const KTHREAD *thread)
+{
+    if (thread == NULL || gExBootstrapThread == NULL || gExBootstrapThread->Thread != thread)
+        return NULL;
+
+    if (gExBootstrapThread->Process == NULL)
+        return NULL;
+
+    return gExBootstrapThread->Process->Staging;
+}
+
+HO_STATUS
+ExBootstrapAdapterHandleRawExit(KTHREAD *thread)
+{
+    EX_PROCESS *process = NULL;
+
+    if (thread == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (gExBootstrapThread == NULL || gExBootstrapThread->Thread != thread)
+        return EC_INVALID_STATE;
+
+    process = gExBootstrapThread->Process;
+    if (process == NULL || process->Staging == NULL)
+        return EC_INVALID_STATE;
+
+    HO_STATUS status = KeUserBootstrapDestroyStaging(process->Staging);
+
+    /* Destroy consumes the staging object even when teardown reports an error. */
+    process->Staging = NULL;
+
+    if (status != EC_SUCCESS)
+    {
+        KiDestroyBootstrapWrapperObjects();
+    }
+
+    return status;
+}
+
+static void
+KiDestroyBootstrapWrapperObjects(void)
+{
+    EX_THREAD *exThread = gExBootstrapThread;
+    EX_PROCESS *process = gExBootstrapProcess;
+
+    gExBootstrapThread = NULL;
+    gExBootstrapProcess = NULL;
+
+    if (exThread != NULL)
+    {
+        exThread->Thread = NULL;
+        exThread->Process = NULL;
+        kfree(exThread);
+    }
+
+    if (process != NULL)
+    {
+        process->Staging = NULL;
+        kfree(process);
+    }
 }

--- a/src/kernel/ex/ex_bootstrap_adapter.c
+++ b/src/kernel/ex/ex_bootstrap_adapter.c
@@ -1,0 +1,142 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ex/ex_bootstrap_adapter.c
+ * Description: Thin Ex bootstrap adapter ownership layer.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#include <kernel/ex/ex_bootstrap_adapter.h>
+#include <kernel/ex/ex_process.h>
+#include <kernel/ex/ex_thread.h>
+#include <kernel/ke/bootstrap_callbacks.h>
+#include <kernel/ke/kthread.h>
+#include <kernel/ke/mm.h>
+#include <kernel/ke/user_bootstrap.h>
+#include <kernel/hodbg.h>
+
+struct EX_PROCESS
+{
+    KE_USER_BOOTSTRAP_STAGING *Staging;
+};
+
+struct EX_THREAD
+{
+    KTHREAD *Thread;
+    EX_PROCESS *Process;
+};
+
+/* Only one bootstrap process/thread wrapper may exist at a time. */
+static EX_PROCESS *gBootstrapProcess = NULL;
+static EX_THREAD *gBootstrapThread = NULL;
+
+static HO_NORETURN void
+ExBootstrapEnterCallback(KTHREAD *thread)
+{
+    HO_STATUS status = ExBootstrapAdapterWrapThread(thread);
+    if (status != EC_SUCCESS)
+    {
+        HO_KPANIC(status, "Failed to wrap bootstrap thread in Ex adapter");
+    }
+
+    KeUserBootstrapEnterCurrentThread();
+}
+
+static HO_STATUS
+ExBootstrapFinalizeCallback(KTHREAD *thread)
+{
+    if (thread != NULL && thread->UserBootstrapContext != NULL)
+    {
+        klog(KLOG_LEVEL_WARNING, "[USERBOOT] fallback staging reclaim in finalizer thread=%u\n", thread->ThreadId);
+    }
+
+    return ExBootstrapAdapterFinalizeThread(thread);
+}
+
+static void
+ExBootstrapTimerObserveCallback(KTHREAD *thread)
+{
+    (void)thread;
+    KeUserBootstrapObserveCurrentThreadUserTimerPreemption();
+}
+
+HO_STATUS
+ExBootstrapAdapterInit(void)
+{
+    return KeRegisterBootstrapCallbacks(ExBootstrapEnterCallback,
+                                        ExBootstrapFinalizeCallback,
+                                        ExBootstrapTimerObserveCallback);
+}
+
+HO_STATUS
+ExBootstrapAdapterWrapThread(KTHREAD *thread)
+{
+    EX_PROCESS *process = NULL;
+    EX_THREAD *exThread = NULL;
+
+    if (gBootstrapThread != NULL && gBootstrapThread->Thread == thread)
+        return EC_SUCCESS;
+
+    if (gBootstrapThread != NULL)
+        return EC_INVALID_STATE;
+
+    if (thread == NULL || thread->UserBootstrapContext == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    process = (EX_PROCESS *)kzalloc(sizeof(*process));
+    if (process == NULL)
+        return EC_OUT_OF_RESOURCE;
+
+    process->Staging = thread->UserBootstrapContext;
+
+    exThread = (EX_THREAD *)kzalloc(sizeof(*exThread));
+    if (exThread == NULL)
+    {
+        kfree(process);
+        return EC_OUT_OF_RESOURCE;
+    }
+
+    exThread->Thread = thread;
+    exThread->Process = process;
+
+    gBootstrapProcess = process;
+    gBootstrapThread = exThread;
+    return EC_SUCCESS;
+}
+
+HO_STATUS
+ExBootstrapAdapterFinalizeThread(KTHREAD *thread)
+{
+    EX_PROCESS *process = NULL;
+    HO_STATUS status = EC_SUCCESS;
+
+    if (gBootstrapThread == NULL || gBootstrapThread->Thread != thread)
+        return EC_SUCCESS;
+
+    process = gBootstrapThread->Process;
+
+    if (process != NULL && process->Staging != NULL)
+    {
+        if (thread->UserBootstrapContext != NULL)
+        {
+            HO_KASSERT(process->Staging == thread->UserBootstrapContext, EC_INVALID_STATE);
+            status = KeUserBootstrapDestroyStaging(process->Staging);
+        }
+
+        /* Destroy consumes the staging object even when teardown reports an error. */
+        process->Staging = NULL;
+    }
+
+    kfree(gBootstrapThread);
+    gBootstrapThread = NULL;
+
+    kfree(gBootstrapProcess);
+    gBootstrapProcess = NULL;
+    return status;
+}
+
+BOOL
+ExBootstrapAdapterHasWrapper(const KTHREAD *thread)
+{
+    return gBootstrapThread != NULL && gBootstrapThread->Thread == thread;
+}

--- a/src/kernel/ex/ex_bootstrap_internal.h
+++ b/src/kernel/ex/ex_bootstrap_internal.h
@@ -1,0 +1,29 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ex/ex_bootstrap_internal.h
+ * Description: Private Ex bootstrap wrapper state shared inside ex/.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#pragma once
+
+#include <kernel/ex/ex_process.h>
+#include <kernel/ex/ex_thread.h>
+
+struct KTHREAD;
+struct KE_USER_BOOTSTRAP_STAGING;
+
+struct EX_PROCESS
+{
+    struct KE_USER_BOOTSTRAP_STAGING *Staging;
+};
+
+struct EX_THREAD
+{
+    struct KTHREAD *Thread;
+    EX_PROCESS *Process;
+};
+
+extern EX_PROCESS *gExBootstrapProcess;
+extern EX_THREAD *gExBootstrapThread;

--- a/src/kernel/init/init.c
+++ b/src/kernel/init/init.c
@@ -1,4 +1,6 @@
 #include "init_internal.h"
+
+#include <kernel/ex/ex_bootstrap_adapter.h>
 #include <kernel/ke/user_bootstrap.h>
 #include <kernel/ke/sysinfo.h>
 
@@ -704,6 +706,12 @@ InitKernel(MAYBE_UNUSED STAGING_BLOCK *block)
     if (initStatus != EC_SUCCESS)
     {
         HO_KPANIC(initStatus, "Failed to initialize bootstrap raw syscall trap");
+    }
+
+    initStatus = ExBootstrapAdapterInit();
+    if (initStatus != EC_SUCCESS)
+    {
+        HO_KPANIC(initStatus, "Failed to initialize Ex bootstrap adapter");
     }
 }
 

--- a/src/kernel/init/init.c
+++ b/src/kernel/init/init.c
@@ -1,7 +1,6 @@
 #include "init_internal.h"
 
-#include <kernel/ex/ex_bootstrap_adapter.h>
-#include <kernel/ke/user_bootstrap.h>
+#include <kernel/ex/ex_bootstrap.h>
 #include <kernel/ke/sysinfo.h>
 
 //
@@ -702,16 +701,10 @@ InitKernel(MAYBE_UNUSED STAGING_BLOCK *block)
         HO_KPANIC(initStatus, "Scheduler observability self-test failed");
     }
 
-    initStatus = KeUserBootstrapRawSyscallInit();
+    initStatus = ExBootstrapInit();
     if (initStatus != EC_SUCCESS)
     {
-        HO_KPANIC(initStatus, "Failed to initialize bootstrap raw syscall trap");
-    }
-
-    initStatus = ExBootstrapAdapterInit();
-    if (initStatus != EC_SUCCESS)
-    {
-        HO_KPANIC(initStatus, "Failed to initialize Ex bootstrap adapter");
+        HO_KPANIC(initStatus, "Failed to initialize Ex bootstrap runtime");
     }
 }
 

--- a/src/kernel/ke/bootstrap_callbacks.c
+++ b/src/kernel/ke/bootstrap_callbacks.c
@@ -9,26 +9,30 @@
 #include <kernel/ke/bootstrap_callbacks.h>
 
 static KE_BOOTSTRAP_ENTER_FN gBootstrapEnterCallback = NULL;
+static KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN gBootstrapThreadOwnershipQueryCallback = NULL;
 static KE_BOOTSTRAP_FINALIZE_FN gBootstrapFinalizeCallback = NULL;
 static KE_BOOTSTRAP_TIMER_OBSERVE_FN gBootstrapTimerObserveCallback = NULL;
 
 HO_KERNEL_API HO_STATUS
 KeRegisterBootstrapCallbacks(KE_BOOTSTRAP_ENTER_FN enterFn,
+                             KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN threadOwnershipQueryFn,
                              KE_BOOTSTRAP_FINALIZE_FN finalizeFn,
                              KE_BOOTSTRAP_TIMER_OBSERVE_FN timerObserveFn)
 {
-    if (enterFn == NULL || finalizeFn == NULL || timerObserveFn == NULL)
+    if (enterFn == NULL || threadOwnershipQueryFn == NULL || finalizeFn == NULL || timerObserveFn == NULL)
     {
         return EC_ILLEGAL_ARGUMENT;
     }
 
-    if (gBootstrapEnterCallback != NULL || gBootstrapFinalizeCallback != NULL ||
+    if (gBootstrapEnterCallback != NULL || gBootstrapThreadOwnershipQueryCallback != NULL ||
+        gBootstrapFinalizeCallback != NULL ||
         gBootstrapTimerObserveCallback != NULL)
     {
         return EC_INVALID_STATE;
     }
 
     gBootstrapEnterCallback = enterFn;
+    gBootstrapThreadOwnershipQueryCallback = threadOwnershipQueryFn;
     gBootstrapFinalizeCallback = finalizeFn;
     gBootstrapTimerObserveCallback = timerObserveFn;
     return EC_SUCCESS;
@@ -38,6 +42,12 @@ KE_BOOTSTRAP_ENTER_FN
 KiGetBootstrapEnterCallback(void)
 {
     return gBootstrapEnterCallback;
+}
+
+KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN
+KiGetBootstrapThreadOwnershipQueryCallback(void)
+{
+    return gBootstrapThreadOwnershipQueryCallback;
 }
 
 KE_BOOTSTRAP_FINALIZE_FN

--- a/src/kernel/ke/bootstrap_callbacks.c
+++ b/src/kernel/ke/bootstrap_callbacks.c
@@ -1,0 +1,53 @@
+/**
+ * HimuOperatingSystem
+ *
+ * File: ke/bootstrap_callbacks.c
+ * Description: Ke-side bootstrap callback registration storage.
+ * Copyright(c) 2024-2026 HimuOS, ONLY FOR EDUCATIONAL PURPOSES.
+ */
+
+#include <kernel/ke/bootstrap_callbacks.h>
+
+static KE_BOOTSTRAP_ENTER_FN gBootstrapEnterCallback = NULL;
+static KE_BOOTSTRAP_FINALIZE_FN gBootstrapFinalizeCallback = NULL;
+static KE_BOOTSTRAP_TIMER_OBSERVE_FN gBootstrapTimerObserveCallback = NULL;
+
+HO_KERNEL_API HO_STATUS
+KeRegisterBootstrapCallbacks(KE_BOOTSTRAP_ENTER_FN enterFn,
+                             KE_BOOTSTRAP_FINALIZE_FN finalizeFn,
+                             KE_BOOTSTRAP_TIMER_OBSERVE_FN timerObserveFn)
+{
+    if (enterFn == NULL || finalizeFn == NULL || timerObserveFn == NULL)
+    {
+        return EC_ILLEGAL_ARGUMENT;
+    }
+
+    if (gBootstrapEnterCallback != NULL || gBootstrapFinalizeCallback != NULL ||
+        gBootstrapTimerObserveCallback != NULL)
+    {
+        return EC_INVALID_STATE;
+    }
+
+    gBootstrapEnterCallback = enterFn;
+    gBootstrapFinalizeCallback = finalizeFn;
+    gBootstrapTimerObserveCallback = timerObserveFn;
+    return EC_SUCCESS;
+}
+
+KE_BOOTSTRAP_ENTER_FN
+KiGetBootstrapEnterCallback(void)
+{
+    return gBootstrapEnterCallback;
+}
+
+KE_BOOTSTRAP_FINALIZE_FN
+KiGetBootstrapFinalizeCallback(void)
+{
+    return gBootstrapFinalizeCallback;
+}
+
+KE_BOOTSTRAP_TIMER_OBSERVE_FN
+KiGetBootstrapTimerObserveCallback(void)
+{
+    return gBootstrapTimerObserveCallback;
+}

--- a/src/kernel/ke/thread/kthread.c
+++ b/src/kernel/ke/thread/kthread.c
@@ -130,7 +130,6 @@ KiThreadCreateInternal(KTHREAD **outThread,
     thread->EntryPoint = entryPoint;
     thread->EntryArg = arg;
     thread->Flags = 0;
-    thread->UserBootstrapContext = NULL;
 
     *outThread = thread;
 

--- a/src/kernel/ke/thread/scheduler/scheduler.c
+++ b/src/kernel/ke/thread/scheduler/scheduler.c
@@ -34,8 +34,9 @@ void
 KiThreadTrampoline(void)
 {
     KTHREAD *self = KeGetCurrentThread();
+    KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN threadOwnershipQueryFn = KiGetBootstrapThreadOwnershipQueryCallback();
 
-    if (self->UserBootstrapContext != NULL)
+    if (threadOwnershipQueryFn != NULL && threadOwnershipQueryFn(self))
     {
         KE_BOOTSTRAP_ENTER_FN enterFn = KiGetBootstrapEnterCallback();
         if (enterFn == NULL)
@@ -94,7 +95,6 @@ KeSchedulerInit(void)
     gIdleThread->EntryPoint = NULL;
     gIdleThread->EntryArg = NULL;
     gIdleThread->Flags = KTHREAD_FLAG_IDLE;
-    gIdleThread->UserBootstrapContext = NULL;
 
     gCurrentThread = gIdleThread;
     KeSetCurrentIrqlState(&gIdleThread->IrqlState);
@@ -293,6 +293,16 @@ KiReleaseThreadJoinClaim(KTHREAD *thread)
     thread->TerminationClaimState = KTHREAD_TERMINATION_CLAIM_STATE_UNCLAIMED;
 }
 
+static BOOL
+KiIsBootstrapOwnedThread(const KTHREAD *thread)
+{
+    KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN threadOwnershipQueryFn = KiGetBootstrapThreadOwnershipQueryCallback();
+    if (thread == NULL || threadOwnershipQueryFn == NULL)
+        return FALSE;
+
+    return threadOwnershipQueryFn(thread);
+}
+
 void
 KiFinalizeThread(KTHREAD *thread)
 {
@@ -301,7 +311,7 @@ KiFinalizeThread(KTHREAD *thread)
     HO_KASSERT(thread->State == KTHREAD_STATE_TERMINATED, EC_INVALID_STATE);
     HO_KASSERT(thread->TerminationClaimState == KTHREAD_TERMINATION_CLAIM_STATE_CONSUMED, EC_INVALID_STATE);
 
-    if ((thread->Flags & KTHREAD_FLAG_BOOTSTRAP_USER) != 0)
+    if (KiIsBootstrapOwnedThread(thread))
     {
         KE_BOOTSTRAP_FINALIZE_FN finalizeFn = KiGetBootstrapFinalizeCallback();
         if (finalizeFn == NULL)
@@ -616,7 +626,7 @@ KiReapTerminatedThreads(void)
         if (!thread)
             return;
 
-        if ((thread->Flags & KTHREAD_FLAG_BOOTSTRAP_USER) != 0)
+        if (KiIsBootstrapOwnedThread(thread))
         {
             klog(KLOG_LEVEL_INFO, "[USERBOOT] idle/reaper reclaimed user_hello thread thread=%u\n",
                  thread->ThreadId);

--- a/src/kernel/ke/thread/scheduler/scheduler.c
+++ b/src/kernel/ke/thread/scheduler/scheduler.c
@@ -9,7 +9,7 @@
 
 #include "scheduler_internal.h"
 
-#include <kernel/ke/user_bootstrap.h>
+#include <kernel/ke/bootstrap_callbacks.h>
 
 // ─────────────────────────────────────────────────────────────
 // Globals
@@ -37,7 +37,13 @@ KiThreadTrampoline(void)
 
     if (self->UserBootstrapContext != NULL)
     {
-        KeUserBootstrapEnterCurrentThread();
+        KE_BOOTSTRAP_ENTER_FN enterFn = KiGetBootstrapEnterCallback();
+        if (enterFn == NULL)
+        {
+            HO_KPANIC(EC_INVALID_STATE, "Bootstrap enter callback not registered");
+        }
+
+        enterFn(self);
     }
 
     ARCH_INTERRUPT_STATE enabledState = {.MaskableInterruptEnabled = TRUE};
@@ -295,13 +301,18 @@ KiFinalizeThread(KTHREAD *thread)
     HO_KASSERT(thread->State == KTHREAD_STATE_TERMINATED, EC_INVALID_STATE);
     HO_KASSERT(thread->TerminationClaimState == KTHREAD_TERMINATION_CLAIM_STATE_CONSUMED, EC_INVALID_STATE);
 
-    if (thread->UserBootstrapContext != NULL)
+    if ((thread->Flags & KTHREAD_FLAG_BOOTSTRAP_USER) != 0)
     {
-        klog(KLOG_LEVEL_WARNING, KE_USER_BOOTSTRAP_LOG_FALLBACK_RECLAIM " thread=%u\n", thread->ThreadId);
-        HO_STATUS stagingStatus = KeUserBootstrapDestroyStaging(thread->UserBootstrapContext);
-        if (stagingStatus != EC_SUCCESS)
+        KE_BOOTSTRAP_FINALIZE_FN finalizeFn = KiGetBootstrapFinalizeCallback();
+        if (finalizeFn == NULL)
         {
-            HO_KPANIC(stagingStatus, "Failed to release terminated KTHREAD user bootstrap staging");
+            HO_KPANIC(EC_INVALID_STATE, "Bootstrap finalize callback not registered");
+        }
+
+        HO_STATUS finalizeStatus = finalizeFn(thread);
+        if (finalizeStatus != EC_SUCCESS)
+        {
+            HO_KPANIC(finalizeStatus, "Failed to release terminated KTHREAD bootstrap resources");
         }
     }
 
@@ -338,7 +349,7 @@ KeThreadExit(void)
     thread->State = KTHREAD_STATE_TERMINATED;
     gStats.ActiveThreadCount--;
 
-    klog(KLOG_LEVEL_INFO, KE_USER_BOOTSTRAP_LOG_THREAD_TERMINATED_FORMAT "\n", thread->ThreadId);
+    klog(KLOG_LEVEL_INFO, "[SCHED] Thread %u terminated\n", thread->ThreadId);
 
     KeLeaveCriticalSection(&criticalSection);
 
@@ -607,7 +618,8 @@ KiReapTerminatedThreads(void)
 
         if ((thread->Flags & KTHREAD_FLAG_BOOTSTRAP_USER) != 0)
         {
-            klog(KLOG_LEVEL_INFO, KE_USER_BOOTSTRAP_LOG_IDLE_REAPER " thread=%u\n", thread->ThreadId);
+            klog(KLOG_LEVEL_INFO, "[USERBOOT] idle/reaper reclaimed user_hello thread thread=%u\n",
+                 thread->ThreadId);
         }
 
         KiFinalizeThread(thread);

--- a/src/kernel/ke/thread/scheduler/timer.c
+++ b/src/kernel/ke/thread/scheduler/timer.c
@@ -9,7 +9,7 @@
 
 #include "scheduler_internal.h"
 
-#include <kernel/ke/user_bootstrap.h>
+#include <kernel/ke/bootstrap_callbacks.h>
 
 uint64_t
 KiNowNs(void)
@@ -38,7 +38,15 @@ KiSchedulerTimerISR(void *frame, void *context)
 
     if (interruptedFromUserMode)
     {
-        KeUserBootstrapObserveCurrentThreadUserTimerPreemption();
+        KE_BOOTSTRAP_TIMER_OBSERVE_FN timerObserveFn = KiGetBootstrapTimerObserveCallback();
+        if (timerObserveFn != NULL)
+        {
+            KTHREAD *current = KeGetCurrentThread();
+            if (current != NULL && current->UserBootstrapContext != NULL)
+            {
+                timerObserveFn(current);
+            }
+        }
     }
 
     uint64_t nowNs = KiNowNs();

--- a/src/kernel/ke/thread/scheduler/timer.c
+++ b/src/kernel/ke/thread/scheduler/timer.c
@@ -39,10 +39,11 @@ KiSchedulerTimerISR(void *frame, void *context)
     if (interruptedFromUserMode)
     {
         KE_BOOTSTRAP_TIMER_OBSERVE_FN timerObserveFn = KiGetBootstrapTimerObserveCallback();
-        if (timerObserveFn != NULL)
+        KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN threadOwnershipQueryFn = KiGetBootstrapThreadOwnershipQueryCallback();
+        if (timerObserveFn != NULL && threadOwnershipQueryFn != NULL)
         {
             KTHREAD *current = KeGetCurrentThread();
-            if (current != NULL && current->UserBootstrapContext != NULL)
+            if (current != NULL && threadOwnershipQueryFn(current))
             {
                 timerObserveFn(current);
             }

--- a/src/kernel/ke/user_bootstrap.c
+++ b/src/kernel/ke/user_bootstrap.c
@@ -7,6 +7,7 @@
  */
 
 #include <arch/amd64/pm.h>
+#include <kernel/ex/ex_bootstrap_adapter.h>
 #include <kernel/ke/mm.h>
 #include <kernel/ke/scheduler.h>
 #include <kernel/ke/user_bootstrap.h>
@@ -211,10 +212,13 @@ static KE_USER_BOOTSTRAP_STAGING *
 KiGetCurrentThreadStaging(void)
 {
     KTHREAD *thread = KeGetCurrentThread();
-    if (!thread || thread->UserBootstrapContext == NULL)
+    if (!thread)
         return NULL;
 
-    KE_USER_BOOTSTRAP_STAGING *staging = thread->UserBootstrapContext;
+    KE_USER_BOOTSTRAP_STAGING *staging = ExBootstrapAdapterQueryThreadStaging(thread);
+    if (staging == NULL)
+        return NULL;
+
     if (staging->AttachedThread != thread)
         return NULL;
 
@@ -330,8 +334,6 @@ KeUserBootstrapDestroyStaging(KE_USER_BOOTSTRAP_STAGING *staging)
 
     if (staging->AttachedThread != NULL)
     {
-        HO_KASSERT(staging->AttachedThread->UserBootstrapContext == staging, EC_INVALID_STATE);
-        staging->AttachedThread->UserBootstrapContext = NULL;
         staging->AttachedThread = NULL;
     }
 
@@ -383,8 +385,6 @@ KeUserBootstrapAttachThread(KTHREAD *thread, KE_USER_BOOTSTRAP_STAGING *staging)
         return EC_INVALID_STATE;
     if (thread->State != KTHREAD_STATE_NEW)
         return EC_INVALID_STATE;
-    if (thread->UserBootstrapContext != NULL && thread->UserBootstrapContext != staging)
-        return EC_INVALID_STATE;
     if (staging->AttachedThread != NULL && staging->AttachedThread != thread)
         return EC_INVALID_STATE;
     if (KiFindMappedPage(staging, KE_USER_BOOTSTRAP_MAPPING_KIND_CODE) == NULL)
@@ -393,7 +393,6 @@ KeUserBootstrapAttachThread(KTHREAD *thread, KE_USER_BOOTSTRAP_STAGING *staging)
         return EC_INVALID_STATE;
 
     staging->AttachedThread = thread;
-    thread->UserBootstrapContext = staging;
     return EC_SUCCESS;
 }
 
@@ -438,9 +437,9 @@ KeUserBootstrapEnterCurrentThread(void)
 {
     KTHREAD *thread = KeGetCurrentThread();
     HO_KASSERT(thread != NULL, EC_INVALID_STATE);
-    HO_KASSERT(thread->UserBootstrapContext != NULL, EC_INVALID_STATE);
 
-    KE_USER_BOOTSTRAP_STAGING *staging = thread->UserBootstrapContext;
+    KE_USER_BOOTSTRAP_STAGING *staging = KiGetCurrentThreadStaging();
+    HO_KASSERT(staging != NULL, EC_INVALID_STATE);
     HO_KASSERT(staging->AttachedThread == thread, EC_INVALID_STATE);
     HO_KASSERT(KiFindMappedPage(staging, KE_USER_BOOTSTRAP_MAPPING_KIND_CODE) != NULL, EC_INVALID_STATE);
     HO_KASSERT(KiFindMappedPage(staging, KE_USER_BOOTSTRAP_MAPPING_KIND_STACK) != NULL, EC_INVALID_STATE);

--- a/src/kernel/ke/user_bootstrap_syscall.c
+++ b/src/kernel/ke/user_bootstrap_syscall.c
@@ -8,6 +8,7 @@
 
 #include <arch/amd64/idt.h>
 #include <arch/amd64/pm.h>
+#include <kernel/ex/ex_bootstrap_adapter.h>
 #include <kernel/hodbg.h>
 #include <kernel/ke/console.h>
 #include <kernel/ke/mm.h>
@@ -223,7 +224,7 @@ static int64_t
 KiHandleRawExit(uint64_t exitCode)
 {
     KTHREAD *thread = KeGetCurrentThread();
-    if (!thread || thread->UserBootstrapContext == NULL)
+    if (!thread || ExBootstrapAdapterQueryThreadStaging(thread) == NULL)
         KiAbortRawExit(thread, exitCode, EC_INVALID_STATE, "Bootstrap raw exit missing staging");
 
     klog(KLOG_LEVEL_INFO,
@@ -231,7 +232,7 @@ KiHandleRawExit(uint64_t exitCode)
          (unsigned long)exitCode,
          thread->ThreadId);
 
-    HO_STATUS status = KeUserBootstrapDestroyStaging(thread->UserBootstrapContext);
+    HO_STATUS status = ExBootstrapAdapterHandleRawExit(thread);
     if (status != EC_SUCCESS)
         KiAbortRawExit(thread, exitCode, status, "Bootstrap raw exit teardown failed after no-return transition");
 
@@ -247,7 +248,7 @@ static int64_t
 KiDispatchRawSyscall(uint64_t rawSyscallNumber, uint64_t arg0, uint64_t arg1, uint64_t arg2)
 {
     KTHREAD *thread = KeGetCurrentThread();
-    if (!thread || thread->UserBootstrapContext == NULL)
+    if (!thread || ExBootstrapAdapterQueryThreadStaging(thread) == NULL)
     {
         if (rawSyscallNumber == SYS_RAW_EXIT)
             KiAbortRawExit(thread, arg0, EC_INVALID_STATE, "Bootstrap raw exit missing staging");


### PR DESCRIPTION
## What changed

This PR introduces a simple Ex bootstrap layer and completes the userspace bootstrap cutover from the older Ke-owned path.

Key changes in this branch:
- add the Ex bootstrap scaffold, ownership types, and adapter entry points
- decouple bootstrap lifecycle callbacks from Ke scheduling paths
- introduce the Ex bootstrap runtime and launch facade
- cut over `user_hello` launch flow to the Ex facade
- remove obsolete Ke bootstrap residue and sync documentation

## Why

The previous bootstrap flow mixed ownership and launch responsibilities across Ke and the userspace bootstrap path. This branch consolidates bootstrap responsibilities behind the Ex layer so the launch path is easier to reason about, easier to evolve, and less coupled to Ke internals.

## Impact

- userspace bootstrap now routes through the Ex facade
- old Ke bootstrap residue is removed from the active path
- docs and migration notes are updated to match the current architecture
- commit history is intentionally grouped into two larger commits for easier review

## Validation

- branch content matches the pre-squash branch state after commit history cleanup
- working tree is clean after rewrite and push
- no additional test run was performed in this publish step
