### PR TITLE
feat(ke): add process-private address-space foundation

### DIFF
--- a/docs/current-ability.md
+++ b/docs/current-ability.md
@@ -30,7 +30,7 @@
 - 已合并 PR `#33` 把 P2 rejected raw write probe / successful hello write / `SYS_RAW_EXIT` 证据链固定下来
 - 当前 HEAD 的 `complete-ex-bootstrap-migration` 已把 bootstrap launch / init / teardown 所有权收口到 Ex：`user_hello` 通过 Ex facade 启动，`InitKernel()` 通过 `ExBootstrapInit()` 统一装配 bootstrap runtime
 - bootstrap ABI 常量、固定窗口约束说明和关键日志锚点现已由 `src/include/kernel/ex/ex_bootstrap_abi.h` 对外暴露；scheduler / timer / finalizer / reaper 通过 Ex 注册的 ownership query 与 callbacks 判断 bootstrap 路径，`KTHREAD_FLAG_BOOTSTRAP_USER` 与 `UserBootstrapContext` 已删除
-- 正式进程地址空间 / 独立 CR3 语义仍未开始落地；这部分从 `complete-ex-bootstrap-migration` 的 Phase B 才开始承接
+- 正式进程地址空间 / 独立 CR3 语义仍未开始落地；这部分现由 `process-private-address-space-foundation` change 中的 process-private root / address-space switching 合同继续承接
 
 ## 当前已支持的功能
 
@@ -76,7 +76,7 @@
 
 这里的用户态能力只指独立 `user_hello` profile 下的最小执行路径与 raw syscall 入口，不应外推为完整进程地址空间、正式系统调用子系统或 Ex 层对象模型。
 
-更具体地说，当前 `user_hello` 只是一条 bootstrap/staging 性质的脚手架测试路径，用来验证“最小用户页映射 -> 首次进入 Ring 3 -> 来自 CPL3 的 P1 timer round-trip -> P1 gate armed -> invalid raw write rejected -> hello write succeeds -> `SYS_RAW_EXIT` -> bootstrap teardown complete -> thread terminated -> idle/reaper reclaimed -> back to idle”这条最小证据链。当前 launch / init / teardown 与对外 bootstrap ABI surface 已由 Ex facade 持有，Ke 继续负责 staging、trap、线程与调度等底层机制；当前代码也已经删除 `KTHREAD_FLAG_BOOTSTRAP_USER` 与 `UserBootstrapContext`，因此 scheduler / timer / finalizer / idle/reaper 只通过 Ex 注册的 ownership query / callback contract 判断是否走 bootstrap 路径。这里的 P1 gate、后续 P2 raw syscall 自检以及当前 HEAD 上进一步补强的 P3 exit/reap 合同，都只是同一个 `user_hello` profile 内部的分阶段验证，不是新增独立的 P1-only、P2-only 或 P3-only profile。现阶段共享 imported root 仍保留 boot 阶段遗留的低 2GB identity mapping，因此 bootstrap 固定用户窗口需要显式避开该区域；这属于当前 bring-up 模型的临时约束，不代表长期用户虚拟地址布局合同，也不意味着当前 bootstrap raw syscall 已经承诺未来正式用户态 ABI。P3 现在明确要求正常路径由 `SYS_RAW_EXIT` 在进入 `KeThreadExit()` 前完成 bootstrap 用户资源释放并打印 `bootstrap teardown complete`，scheduler finalizer 只保留 `fallback staging reclaim` 这类防御性兜底语义。而 `complete-ex-bootstrap-migration` 的 Phase B 才开始承接正式地址空间语义：届时系统预期会为用户态重建或派生独立页表根，并以干净的 low-half 布局替代当前 fixed bootstrap window，因此这条 staging 限制与长期目标并不冲突。
+更具体地说，当前 `user_hello` 只是一条 bootstrap/staging 性质的脚手架测试路径，用来验证“最小用户页映射 -> 首次进入 Ring 3 -> 来自 CPL3 的 P1 timer round-trip -> P1 gate armed -> invalid raw write rejected -> hello write succeeds -> `SYS_RAW_EXIT` -> bootstrap teardown complete -> thread terminated -> idle/reaper reclaimed -> back to idle”这条最小证据链。当前 launch / init / teardown 与对外 bootstrap ABI surface 已由 Ex facade 持有，Ke 继续负责 staging、trap、线程与调度等底层机制；当前代码也已经删除 `KTHREAD_FLAG_BOOTSTRAP_USER` 与 `UserBootstrapContext`，因此 scheduler / timer / finalizer / idle/reaper 只通过 Ex 注册的 ownership query / callback contract 判断是否走 bootstrap 路径。这里的 P1 gate、后续 P2 raw syscall 自检以及当前 HEAD 上进一步补强的 P3 exit/reap 合同，都只是同一个 `user_hello` profile 内部的分阶段验证，不是新增独立的 P1-only、P2-only 或 P3-only profile。现阶段共享 imported root 仍保留 boot 阶段遗留的低 2GB identity mapping，因此当前 bootstrap 固定用户窗口只是一个 Phase A/bootstrap-only 的历史遗留窗口，需要显式避开该区域；这属于当前 bring-up 模型的临时约束，不代表长期用户虚拟地址布局合同，也不意味着当前 bootstrap raw syscall 已经承诺未来正式用户态 ABI。P3 现在明确要求正常路径由 `SYS_RAW_EXIT` 在进入 `KeThreadExit()` 前完成 bootstrap 用户资源释放并打印 `bootstrap teardown complete`，scheduler finalizer 只保留 `fallback staging reclaim` 这类防御性兜底语义。而正式地址空间语义则由当前 `process-private-address-space-foundation` change 定义的 process-private root / address-space switching 合同继续承接：届时系统预期会为用户态重建或派生独立页表根，并以干净的 low-half 布局替代当前 fixed bootstrap window，因此这条 staging 限制与长期目标并不冲突。
 
 它已经不只是“能启动的内核骨架”，而是具备以下连续能力链：
 
@@ -104,7 +104,7 @@
 | 待完成功能 | 为什么仍算缺口 | 现有状态 |
 | --- | --- | --- |
 | 完整用户态子系统 / 通用用户程序模型 | README 明确承诺“内核态与用户态安全隔离” | 当前只有挂在独立 `user_hello` profile 下的 bootstrap-only 最小执行路径，尚不具备通用用户程序装载、可恢复故障或稳定用户对象模型 |
-| 正式进程地址空间 / 进程级地址空间切换 | README 把虚拟内存目标描述为“为内核和用户程序提供隔离地址空间” | 这部分从 `complete-ex-bootstrap-migration` 的 Phase B 才开始承接；当前用户页仍以 staging 方式挂在 imported root 上，不是正式进程地址空间模型 |
+| 正式进程地址空间 / 进程级地址空间切换 | README 把虚拟内存目标描述为“为内核和用户程序提供隔离地址空间” | 这部分现由 `process-private-address-space-foundation` change 中的 process-private root / address-space switching 合同承接；当前用户页仍以 staging 方式挂在 imported root 上，不是正式进程地址空间模型 |
 | handle-oriented 正式 syscall 表面 | README 明确承诺“系统调用是用户态获取内核服务的唯一入口” | 当前只有同步 `int 0x80` 的 bootstrap raw syscall 入口，且 ABI 仅限 `SYS_RAW_WRITE` / `SYS_RAW_EXIT`，还不是正式的 handle-oriented syscall 接口 |
 | Ex 层 / Object Manager | 只有 bootstrap 适配薄壳 | 当前 Ex 已成为 bootstrap launch / init / teardown owner，并对外暴露 bootstrap facade / ABI；但这仍只是 bootstrap-only 薄运行时，不具备正式对象管理器、对象命名/生命周期框架或通用进程模型 |
 | Capability 句柄模型 | README 把它作为用户态/内核态隔离的重要机制 | 当前没有对象句柄表、capability 校验、句柄引用/销毁等子系统 |

--- a/src/include/kernel/ex/ex_bootstrap_abi.h
+++ b/src/include/kernel/ex/ex_bootstrap_abi.h
@@ -11,9 +11,10 @@
 #include <_hobase.h>
 
 /*
- * The fixed low-half user window below is a staging/bootstrap model only.
- * It reuses the shared imported kernel root for the first user-mode slice and
- * must not be treated as the long-term per-process address-space contract.
+ * The fixed low-half user window below records the Phase A bootstrap-only
+ * history. It reuses the shared imported kernel root for the first user-mode
+ * slice and must not be treated as the long-term per-process address-space
+ * contract. Phase B process-private roots are expected to replace this window.
  * Keep it above the boot-time low 2GB identity import so hole validation sees
  * an unmapped slot in the shared root.
  */

--- a/src/include/kernel/ke/mm.h
+++ b/src/include/kernel/ke/mm.h
@@ -54,6 +54,12 @@ typedef struct KE_KERNEL_ADDRESS_SPACE
     BOOL Initialized;
 } KE_KERNEL_ADDRESS_SPACE;
 
+typedef struct KE_PROCESS_ADDRESS_SPACE
+{
+    HO_PHYSICAL_ADDRESS RootPageTablePhys;
+    BOOL Initialized;
+} KE_PROCESS_ADDRESS_SPACE;
+
 typedef struct KE_PT_MAPPING
 {
     BOOL Present;
@@ -233,6 +239,27 @@ HO_KERNEL_API HO_NODISCARD HO_STATUS KeImportKernelAddressSpace(struct BOOT_CAPS
 HO_KERNEL_API const KE_KERNEL_ADDRESS_SPACE *KeGetKernelAddressSpace(void);
 
 /**
+ * Create or destroy a process-private root page-table handle.
+ *
+ * KeGetKernelAddressSpace() remains the public accessor for the imported kernel root. These APIs define the minimal
+ * mechanism boundary for distinct process-private roots without changing existing imported-root callers. The create
+ * entry treats outSpace as pure output storage and does not inspect its incoming contents.
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeCreateProcessAddressSpace(KE_PROCESS_ADDRESS_SPACE *outSpace);
+
+HO_KERNEL_API HO_STATUS KeDestroyProcessAddressSpace(KE_PROCESS_ADDRESS_SPACE *space);
+
+/**
+ * Query or switch the active root page table by physical address.
+ *
+ * This is a strategy-free mechanism surface for process-private roots. KeSwitchAddressSpace() does not take
+ * EX_PROCESS* or KTHREAD* and leaves ownership and scheduling policy to higher layers.
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeQueryActiveRootPageTable(HO_PHYSICAL_ADDRESS *outRootPageTablePhys);
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeSwitchAddressSpace(HO_PHYSICAL_ADDRESS rootPageTablePhys);
+
+/**
  * Find the most specific imported region that covers a virtual address.
  *
  * The imported region list remains manifest-derived and may contain semantic overlays inside broader windows such as
@@ -283,10 +310,11 @@ HO_KERNEL_API HO_NODISCARD HO_STATUS KePtProtectPage(const KE_KERNEL_ADDRESS_SPA
                                                      uint64_t attributes);
 
 /**
- * Run a boot-time PT HAL scratch mapping self-test in a safe high-half hole.
+ * Run boot-time imported-root and private-root PT self-tests.
  *
- * This verifies query/map/protect/unmap behavior against the imported root while keeping HHDM as the bootstrap escape
- * hatch. The self-test performs local TLB maintenance only and leaves no persistent scratch mapping behind.
+ * This verifies imported-root query/map/protect/unmap behavior in a safe high-half hole and exercises private-root
+ * create/switch/destroy coverage while keeping HHDM as the bootstrap escape hatch. The self-test performs local TLB
+ * maintenance only and leaves no persistent scratch mapping or private root behind.
  */
 HO_KERNEL_API HO_NODISCARD HO_STATUS KePtSelfTest(void);
 

--- a/src/kernel/ke/mm/address_space.c
+++ b/src/kernel/ke/mm/address_space.c
@@ -340,6 +340,205 @@ KiFindScratchHole(const KE_KERNEL_ADDRESS_SPACE *space, HO_VIRTUAL_ADDRESS *outV
     return EC_NOT_SUPPORTED;
 }
 
+static void
+KiCopyImportedKernelHighHalfMappings(PAGE_TABLE_ENTRY *destinationPml4, const PAGE_TABLE_ENTRY *sourcePml4)
+{
+    const uint32_t highHalfStart = ENTRIES_PER_TABLE / 2;
+
+    memcpy(&destinationPml4[highHalfStart], &sourcePml4[highHalfStart],
+           (ENTRIES_PER_TABLE - highHalfStart) * sizeof(PAGE_TABLE_ENTRY));
+}
+
+static HO_STATUS
+KiDestroyOwnedPageTableSubtree(HO_PHYSICAL_ADDRESS tablePhys, uint8_t level)
+{
+    HO_STATUS firstError = EC_SUCCESS;
+    PAGE_TABLE_ENTRY *table = KiTableFromPhys(tablePhys);
+
+    if (level > 1)
+    {
+        for (uint32_t idx = 0; idx < ENTRIES_PER_TABLE; ++idx)
+        {
+            PAGE_TABLE_ENTRY entry = table[idx];
+
+            if ((entry & PTE_PRESENT) == 0)
+                continue;
+
+            if ((entry & PTE_PAGE_SIZE) != 0)
+                continue;
+
+            HO_STATUS childStatus = KiDestroyOwnedPageTableSubtree(entry & PAGE_MASK, level - 1);
+            if (childStatus != EC_SUCCESS && firstError == EC_SUCCESS)
+            {
+                firstError = childStatus;
+            }
+        }
+    }
+
+    HO_STATUS freeStatus = KePmmFreePages(tablePhys, 1);
+    if (freeStatus != EC_SUCCESS && firstError == EC_SUCCESS)
+    {
+        firstError = freeStatus;
+    }
+
+    return firstError;
+}
+
+static HO_STATUS
+KiValidatePrivateRootLayout(const KE_KERNEL_ADDRESS_SPACE *space, const KE_PROCESS_ADDRESS_SPACE *privateSpace)
+{
+    if (!space || !privateSpace)
+        return EC_ILLEGAL_ARGUMENT;
+
+    PAGE_TABLE_ENTRY *privateRoot = KiTableFromPhys(privateSpace->RootPageTablePhys);
+    PAGE_TABLE_ENTRY *importedRoot = KiTableFromPhys(space->RootPageTablePhys);
+    const uint32_t highHalfStart = ENTRIES_PER_TABLE / 2;
+
+    for (uint32_t idx = 0; idx < highHalfStart; ++idx)
+    {
+        if (privateRoot[idx] != 0)
+        {
+            klog(KLOG_LEVEL_ERROR, "[MM] private root self-test low-half entry unexpectedly populated: pml4[%u]=%p\n",
+                 idx, (void *)(uint64_t)privateRoot[idx]);
+            return EC_INVALID_STATE;
+        }
+    }
+
+    for (uint32_t idx = highHalfStart; idx < ENTRIES_PER_TABLE; ++idx)
+    {
+        if (privateRoot[idx] != importedRoot[idx])
+        {
+            klog(KLOG_LEVEL_ERROR,
+                 "[MM] private root self-test high-half mismatch: pml4[%u]=%p imported=%p\n", idx,
+                 (void *)(uint64_t)privateRoot[idx], (void *)(uint64_t)importedRoot[idx]);
+            return EC_INVALID_STATE;
+        }
+    }
+
+    return EC_SUCCESS;
+}
+
+static HO_STATUS
+KiPrivateRootSelfTest(const KE_KERNEL_ADDRESS_SPACE *space)
+{
+    if (!space || !space->Initialized)
+        return EC_ILLEGAL_ARGUMENT;
+
+    KE_PROCESS_ADDRESS_SPACE privateSpace;
+    memset(&privateSpace, 0, sizeof(privateSpace));
+
+    HO_PHYSICAL_ADDRESS activeRoot = 0;
+    HO_PHYSICAL_ADDRESS privateRootPhys = 0;
+    HO_STATUS status = KeQueryActiveRootPageTable(&activeRoot);
+    if (status != EC_SUCCESS)
+        return status;
+
+    if (activeRoot != space->RootPageTablePhys)
+    {
+        klog(KLOG_LEVEL_ERROR, "[MM] private root self-test expected imported root active before switch: active=%p imported=%p\n",
+             (void *)(uint64_t)activeRoot, (void *)(uint64_t)space->RootPageTablePhys);
+        return EC_INVALID_STATE;
+    }
+
+    status = KeCreateProcessAddressSpace(&privateSpace);
+    if (status != EC_SUCCESS)
+        return status;
+
+    privateRootPhys = privateSpace.RootPageTablePhys;
+
+    if (!privateSpace.Initialized || privateSpace.RootPageTablePhys == 0 ||
+        privateSpace.RootPageTablePhys == space->RootPageTablePhys)
+    {
+        klog(KLOG_LEVEL_ERROR, "[MM] private root self-test create mismatch: initialized=%u private=%p imported=%p\n",
+             privateSpace.Initialized, (void *)(uint64_t)privateSpace.RootPageTablePhys,
+             (void *)(uint64_t)space->RootPageTablePhys);
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+
+    status = KiValidatePrivateRootLayout(space, &privateSpace);
+    if (status != EC_SUCCESS)
+        goto cleanup;
+
+    status = KeSwitchAddressSpace(privateSpace.RootPageTablePhys);
+    if (status != EC_SUCCESS)
+        goto cleanup;
+
+    status = KeQueryActiveRootPageTable(&activeRoot);
+    if (status != EC_SUCCESS)
+        goto cleanup;
+
+    if (activeRoot != privateSpace.RootPageTablePhys)
+    {
+        klog(KLOG_LEVEL_ERROR, "[MM] private root self-test switch query mismatch: active=%p private=%p\n",
+             (void *)(uint64_t)activeRoot, (void *)(uint64_t)privateSpace.RootPageTablePhys);
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+
+    HO_STATUS destroyWhileActiveStatus = KeDestroyProcessAddressSpace(&privateSpace);
+    if (destroyWhileActiveStatus != EC_INVALID_STATE)
+    {
+        klog(KLOG_LEVEL_ERROR, "[MM] private root self-test destroy-while-active should be rejected: status=%k\n",
+             destroyWhileActiveStatus);
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+
+    status = KeSwitchAddressSpace(space->RootPageTablePhys);
+    if (status != EC_SUCCESS)
+        goto cleanup;
+
+    status = KeQueryActiveRootPageTable(&activeRoot);
+    if (status != EC_SUCCESS)
+        goto cleanup;
+
+    if (activeRoot != space->RootPageTablePhys)
+    {
+        klog(KLOG_LEVEL_ERROR, "[MM] private root self-test expected imported root active after restore: active=%p imported=%p\n",
+             (void *)(uint64_t)activeRoot, (void *)(uint64_t)space->RootPageTablePhys);
+        status = EC_INVALID_STATE;
+        goto cleanup;
+    }
+
+    status = KeDestroyProcessAddressSpace(&privateSpace);
+    if (status != EC_SUCCESS)
+        goto cleanup;
+
+    klog(KLOG_LEVEL_INFO, "[MM] private root self-test OK: imported=%p private=%p\n",
+            (void *)(uint64_t)space->RootPageTablePhys, (void *)(uint64_t)privateRootPhys);
+    return EC_SUCCESS;
+
+cleanup:
+    if (privateSpace.Initialized && KiReadCr3() == privateSpace.RootPageTablePhys)
+    {
+        HO_STATUS restoreStatus = KeSwitchAddressSpace(space->RootPageTablePhys);
+        if (restoreStatus != EC_SUCCESS)
+        {
+            klog(KLOG_LEVEL_WARNING, "[MM] private root self-test restore switch failed: %k\n", restoreStatus);
+            if (status == EC_SUCCESS)
+            {
+                status = restoreStatus;
+            }
+        }
+    }
+
+    if (privateSpace.Initialized)
+    {
+        HO_STATUS destroyStatus = KeDestroyProcessAddressSpace(&privateSpace);
+        if (destroyStatus != EC_SUCCESS)
+        {
+            klog(KLOG_LEVEL_WARNING, "[MM] private root self-test cleanup destroy failed: %k\n", destroyStatus);
+            if (status == EC_SUCCESS)
+            {
+                status = destroyStatus;
+            }
+        }
+    }
+
+    return status;
+}
+
 HO_KERNEL_API HO_NODISCARD HO_STATUS
 KeImportKernelAddressSpace(struct BOOT_CAPSULE *capsule, const BOOT_MAPPING_MANIFEST_HEADER *manifest)
 {
@@ -456,6 +655,97 @@ HO_KERNEL_API const KE_KERNEL_ADDRESS_SPACE *
 KeGetKernelAddressSpace(void)
 {
     return gKernelAddressSpace.Initialized ? &gKernelAddressSpace : NULL;
+}
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS
+KeCreateProcessAddressSpace(KE_PROCESS_ADDRESS_SPACE *outSpace)
+{
+    if (!outSpace)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (!gKernelAddressSpace.Initialized)
+        return EC_INVALID_STATE;
+
+    KE_PROCESS_ADDRESS_SPACE newSpace;
+    memset(&newSpace, 0, sizeof(newSpace));
+
+    HO_PHYSICAL_ADDRESS rootPageTablePhys = 0;
+    HO_STATUS status = KePmmAllocPages(1, NULL, &rootPageTablePhys);
+    if (status != EC_SUCCESS)
+        return status;
+
+    PAGE_TABLE_ENTRY *privateRoot = KiTableFromPhys(rootPageTablePhys);
+    PAGE_TABLE_ENTRY *importedRoot = KiTableFromPhys(gKernelAddressSpace.RootPageTablePhys);
+    memset(privateRoot, 0, PAGE_4KB);
+    KiCopyImportedKernelHighHalfMappings(privateRoot, importedRoot);
+
+    newSpace.RootPageTablePhys = rootPageTablePhys;
+    newSpace.Initialized = TRUE;
+    *outSpace = newSpace;
+    return EC_SUCCESS;
+}
+
+HO_KERNEL_API HO_STATUS
+KeDestroyProcessAddressSpace(KE_PROCESS_ADDRESS_SPACE *space)
+{
+    if (!space)
+        return EC_ILLEGAL_ARGUMENT;
+    if (!space->Initialized)
+        return EC_INVALID_STATE;
+    if (KiReadCr3() == space->RootPageTablePhys)
+        return EC_INVALID_STATE;
+
+    HO_STATUS firstError = EC_SUCCESS;
+    PAGE_TABLE_ENTRY *root = KiTableFromPhys(space->RootPageTablePhys);
+
+    for (uint32_t idx = 0; idx < ENTRIES_PER_TABLE / 2; ++idx)
+    {
+        PAGE_TABLE_ENTRY entry = root[idx];
+
+        if ((entry & PTE_PRESENT) == 0)
+            continue;
+
+        if ((entry & PTE_PAGE_SIZE) != 0)
+            continue;
+
+        HO_STATUS childStatus = KiDestroyOwnedPageTableSubtree(entry & PAGE_MASK, 3);
+        if (childStatus != EC_SUCCESS && firstError == EC_SUCCESS)
+        {
+            firstError = childStatus;
+        }
+    }
+
+    HO_STATUS freeStatus = KePmmFreePages(space->RootPageTablePhys, 1);
+    if (freeStatus != EC_SUCCESS && firstError == EC_SUCCESS)
+    {
+        firstError = freeStatus;
+    }
+
+    memset(space, 0, sizeof(*space));
+    return firstError;
+}
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS
+KeQueryActiveRootPageTable(HO_PHYSICAL_ADDRESS *outRootPageTablePhys)
+{
+    if (!outRootPageTablePhys)
+        return EC_ILLEGAL_ARGUMENT;
+
+    *outRootPageTablePhys = KiReadCr3();
+    return EC_SUCCESS;
+}
+
+HO_KERNEL_API HO_NODISCARD HO_STATUS
+KeSwitchAddressSpace(HO_PHYSICAL_ADDRESS rootPageTablePhys)
+{
+    if (rootPageTablePhys == 0 || !HO_IS_ALIGNED(rootPageTablePhys, PAGE_4KB))
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (KiReadCr3() == rootPageTablePhys)
+        return EC_SUCCESS;
+
+    LoadCR3(rootPageTablePhys);
+    return EC_SUCCESS;
 }
 
 HO_KERNEL_API const KE_IMPORTED_REGION *
@@ -669,7 +959,7 @@ KePtSelfTest(void)
         return EC_INVALID_STATE;
     }
 
-    HO_PHYSICAL_ADDRESS scratchPhys;
+    HO_PHYSICAL_ADDRESS scratchPhys = 0;
     status = KePmmAllocPages(1, NULL, &scratchPhys);
     if (status != EC_SUCCESS)
         return status;
@@ -750,10 +1040,11 @@ KePtSelfTest(void)
 
     klog(KLOG_LEVEL_INFO, "[MM] PT HAL scratch OK: va=%p phys=%p\n", (void *)(uint64_t)scratchVirt,
          (void *)(uint64_t)scratchPhys);
-    status = EC_SUCCESS;
+    status = KiPrivateRootSelfTest(space);
 
 cleanup_page:
-    (void)KePmmFreePages(scratchPhys, 1);
+    if (scratchPhys != 0)
+        (void)KePmmFreePages(scratchPhys, 1);
     return status;
 
 cleanup_mapping: {


### PR DESCRIPTION
## What changed

- add `KE_PROCESS_ADDRESS_SPACE` plus `KeCreateProcessAddressSpace()` / `KeDestroyProcessAddressSpace()` so higher layers can own distinct process-private root page tables without changing existing imported-root callers
- add `KeQueryActiveRootPageTable()` and `KeSwitchAddressSpace()` as a mechanism-only CR3 surface that stays independent from `EX_PROCESS` and scheduler policy
- teach the MM self-test to create a private root, verify low-half isolation and high-half kernel mapping inheritance, switch into it, reject destroy-while-active, restore the imported root, and cleanly destroy the private root
- update bootstrap ABI and ability docs so the fixed low-half bootstrap window is explicitly documented as a Phase A historical constraint that will be replaced by process-private roots

## Why

The current `user_hello` bootstrap path still stages user mappings on the imported kernel root. That is good enough for bootstrap bring-up, but it is not the long-term per-process address-space contract promised by the project. This PR lays down the mechanism boundary for process-private roots and root switching so later work can build real per-process address-space ownership and scheduling policy on top.

## Impact

- establishes a minimal kernel MM contract for process-private roots without coupling it to Ex process objects yet
- preserves existing imported-root behavior for current bootstrap callers
- gives later process work a validated CR3 switching boundary and cleanup path to extend instead of replacing ad hoc bootstrap assumptions

## Validation

- `make kernel`
