### PR TITLE
ex: make EX_PROCESS the address-space owner for bootstrap

### DIFF
--- a/src/include/kernel/ex/ex_bootstrap_abi.h
+++ b/src/include/kernel/ex/ex_bootstrap_abi.h
@@ -11,12 +11,12 @@
 #include <_hobase.h>
 
 /*
- * The fixed low-half user window below records the Phase A bootstrap-only
- * history. It reuses the shared imported kernel root for the first user-mode
- * slice and must not be treated as the long-term per-process address-space
- * contract. Phase B process-private roots are expected to replace this window.
- * Keep it above the boot-time low 2GB identity import so hole validation sees
- * an unmapped slot in the shared root.
+ * Fixed low-half bootstrap-only layout.  These constants define the user
+ * window that the bootstrap staging path maps for each process.  When the
+ * owning EX_PROCESS holds a process-private root, the pages live in that
+ * root's low-half rather than the shared imported kernel root.  The layout
+ * constants remain fixed for the bootstrap-only slice; a dynamic per-process
+ * layout allocator is a future phase.
  */
 #define KE_USER_BOOTSTRAP_PAGE_SIZE              0x1000ULL
 #define KE_USER_BOOTSTRAP_WINDOW_BASE            0x0000000080000000ULL

--- a/src/include/kernel/ke/user_bootstrap.h
+++ b/src/include/kernel/ke/user_bootstrap.h
@@ -11,6 +11,7 @@
 #include <_hobase.h>
 
 #include <kernel/ex/ex_bootstrap_abi.h>
+#include <kernel/ke/mm.h>
 #include <kernel/ke/kthread.h>
 
 typedef struct KE_USER_BOOTSTRAP_STAGING KE_USER_BOOTSTRAP_STAGING;
@@ -26,6 +27,7 @@ typedef struct KE_USER_BOOTSTRAP_CREATE_PARAMS
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapCreateStaging(
     const KE_USER_BOOTSTRAP_CREATE_PARAMS *params,
+    KE_PROCESS_ADDRESS_SPACE *targetSpace,
     KE_USER_BOOTSTRAP_STAGING **outStaging);
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapDestroyStaging(KE_USER_BOOTSTRAP_STAGING *staging);

--- a/src/kernel/ex/ex_bootstrap.c
+++ b/src/kernel/ex/ex_bootstrap.c
@@ -70,15 +70,23 @@ ExBootstrapCreateProcess(const EX_BOOTSTRAP_PROCESS_CREATE_PARAMS *params, EX_PR
     keParams.ConstBytes = params->ConstBytes;
     keParams.ConstLength = params->ConstLength;
 
-    HO_STATUS status = KeUserBootstrapCreateStaging(&keParams, &staging);
-    if (status != EC_SUCCESS)
-        return status;
-
     process = (EX_PROCESS *)kzalloc(sizeof(*process));
     if (process == NULL)
+        return EC_OUT_OF_RESOURCE;
+
+    HO_STATUS status = KeCreateProcessAddressSpace(&process->AddressSpace);
+    if (status != EC_SUCCESS)
     {
-        status = KeUserBootstrapDestroyStaging(staging);
-        return status == EC_SUCCESS ? EC_OUT_OF_RESOURCE : status;
+        kfree(process);
+        return status;
+    }
+
+    status = KeUserBootstrapCreateStaging(&keParams, &process->AddressSpace, &staging);
+    if (status != EC_SUCCESS)
+    {
+        HO_STATUS destroyStatus = KeDestroyProcessAddressSpace(&process->AddressSpace);
+        kfree(process);
+        return destroyStatus == EC_SUCCESS ? status : destroyStatus;
     }
 
     process->Staging = staging;
@@ -103,6 +111,15 @@ ExBootstrapDestroyProcess(EX_PROCESS *process)
 
         /* Destroy consumes the staging object even when teardown reports an error. */
         process->Staging = NULL;
+    }
+
+    if (process->AddressSpace.Initialized)
+    {
+        HO_STATUS addrStatus = KeDestroyProcessAddressSpace(&process->AddressSpace);
+        if (addrStatus != EC_SUCCESS && status == EC_SUCCESS)
+        {
+            status = addrStatus;
+        }
     }
 
     kfree(process);
@@ -204,6 +221,15 @@ ExBootstrapTeardownThread(EX_THREAD *thread)
 
         /* Destroy consumes the staging object even when teardown reports an error. */
         process->Staging = NULL;
+    }
+
+    if (process != NULL && process->AddressSpace.Initialized)
+    {
+        HO_STATUS addrStatus = KeDestroyProcessAddressSpace(&process->AddressSpace);
+        if (firstError == EC_SUCCESS)
+        {
+            firstError = addrStatus;
+        }
     }
 
     HO_STATUS threadStatus = KiDestroyNewThread(thread->Thread);

--- a/src/kernel/ex/ex_bootstrap_adapter.c
+++ b/src/kernel/ex/ex_bootstrap_adapter.c
@@ -8,7 +8,9 @@
 
 #include "ex_bootstrap_internal.h"
 
+#include <arch/amd64/pm.h>
 #include <kernel/ex/ex_bootstrap_adapter.h>
+#include <kernel/init.h>
 #include <kernel/ke/bootstrap_callbacks.h>
 #include <kernel/ke/kthread.h>
 #include <kernel/ke/mm.h>
@@ -25,6 +27,32 @@ ExBootstrapEnterCallback(KTHREAD *thread)
     {
         HO_KPANIC(status, "Failed to wrap bootstrap thread in Ex adapter");
     }
+
+    if (gExBootstrapProcess == NULL || !gExBootstrapProcess->AddressSpace.Initialized)
+    {
+        HO_KPANIC(EC_INVALID_STATE, "Bootstrap enter: process root not initialized");
+    }
+
+    status = KeSwitchAddressSpace(gExBootstrapProcess->AddressSpace.RootPageTablePhys);
+    if (status != EC_SUCCESS)
+    {
+        HO_KPANIC(status, "Bootstrap enter: failed to install process root");
+    }
+
+    BOOT_CAPSULE *bootCapsule = KeGetBootCapsule();
+    if (bootCapsule == NULL)
+    {
+        HO_KPANIC(EC_INVALID_STATE, "Bootstrap enter: boot capsule unavailable");
+    }
+
+    TSS64 tss = bootCapsule->CpuInfo.Tss;
+    if (InitCpuCoreLocalData(&bootCapsule->CpuInfo, sizeof(bootCapsule->CpuInfo)) == NULL)
+    {
+        HO_KPANIC(EC_INVALID_STATE, "Bootstrap enter: failed to rebuild high-half GDT/TSS");
+    }
+
+    bootCapsule->CpuInfo.Tss = tss;
+    LoadGdtAndTss(&bootCapsule->CpuInfo);
 
     KeUserBootstrapEnterCurrentThread();
 }
@@ -88,12 +116,38 @@ ExBootstrapAdapterFinalizeThread(KTHREAD *thread)
 
     process = gExBootstrapThread->Process;
 
+    /* Ensure the kernel root is active before tearing down the process root. */
+    if (process != NULL && process->AddressSpace.Initialized)
+    {
+        HO_PHYSICAL_ADDRESS activeRoot = 0;
+        if (KeQueryActiveRootPageTable(&activeRoot) == EC_SUCCESS &&
+            activeRoot == process->AddressSpace.RootPageTablePhys)
+        {
+            const KE_KERNEL_ADDRESS_SPACE *kernelSpace = KeGetKernelAddressSpace();
+            HO_STATUS switchStatus = KeSwitchAddressSpace(kernelSpace->RootPageTablePhys);
+            if (switchStatus != EC_SUCCESS)
+                status = switchStatus;
+        }
+    }
+
     if (process != NULL && process->Staging != NULL)
     {
-        status = KeUserBootstrapDestroyStaging(process->Staging);
-
-        /* Destroy consumes the staging object even when teardown reports an error. */
+        HO_STATUS stagingStatus = KeUserBootstrapDestroyStaging(process->Staging);
         process->Staging = NULL;
+
+        if (status == EC_SUCCESS)
+        {
+            status = stagingStatus;
+        }
+    }
+
+    if (process != NULL && process->AddressSpace.Initialized)
+    {
+        HO_STATUS addrStatus = KeDestroyProcessAddressSpace(&process->AddressSpace);
+        if (status == EC_SUCCESS)
+        {
+            status = addrStatus;
+        }
     }
 
     KiDestroyBootstrapWrapperObjects();
@@ -133,17 +187,31 @@ ExBootstrapAdapterHandleRawExit(KTHREAD *thread)
     if (process == NULL || process->Staging == NULL)
         return EC_INVALID_STATE;
 
-    HO_STATUS status = KeUserBootstrapDestroyStaging(process->Staging);
+    /* Restore the kernel root before teardown so DestroyProcessAddressSpace
+       sees a non-active root and staging unmap operates on a non-active PT. */
+    const KE_KERNEL_ADDRESS_SPACE *kernelSpace = KeGetKernelAddressSpace();
+    HO_STATUS status = KeSwitchAddressSpace(kernelSpace->RootPageTablePhys);
+    if (status != EC_SUCCESS)
+        return status;
 
-    /* Destroy consumes the staging object even when teardown reports an error. */
+    HO_STATUS stagingStatus = KeUserBootstrapDestroyStaging(process->Staging);
     process->Staging = NULL;
 
-    if (status != EC_SUCCESS)
+    if (process->AddressSpace.Initialized)
+    {
+        HO_STATUS addrStatus = KeDestroyProcessAddressSpace(&process->AddressSpace);
+        if (stagingStatus == EC_SUCCESS)
+        {
+            stagingStatus = addrStatus;
+        }
+    }
+
+    if (stagingStatus != EC_SUCCESS)
     {
         KiDestroyBootstrapWrapperObjects();
     }
 
-    return status;
+    return stagingStatus;
 }
 
 static void

--- a/src/kernel/ex/ex_bootstrap_internal.h
+++ b/src/kernel/ex/ex_bootstrap_internal.h
@@ -10,12 +10,14 @@
 
 #include <kernel/ex/ex_process.h>
 #include <kernel/ex/ex_thread.h>
+#include <kernel/ke/mm.h>
 
 struct KTHREAD;
 struct KE_USER_BOOTSTRAP_STAGING;
 
 struct EX_PROCESS
 {
+    KE_PROCESS_ADDRESS_SPACE AddressSpace;
     struct KE_USER_BOOTSTRAP_STAGING *Staging;
 };
 

--- a/src/kernel/ke/user_bootstrap.c
+++ b/src/kernel/ke/user_bootstrap.c
@@ -43,6 +43,7 @@ struct KE_USER_BOOTSTRAP_STAGING
     BOOL PhaseOneFirstEntryObserved;
     BOOL PhaseOneGateArmed;
     uint32_t MappingCount;
+    HO_PHYSICAL_ADDRESS OwnerRootPageTablePhys;
     KTHREAD *AttachedThread;
     KE_USER_BOOTSTRAP_MAPPING_RECORD Mappings[KE_USER_BOOTSTRAP_MAX_MAPPINGS];
 };
@@ -53,6 +54,7 @@ extern HO_NORETURN void KiUserBootstrapIretq(HO_VIRTUAL_ADDRESS userRip,
                                              uint64_t userCs,
                                              uint64_t userSs);
 
+static void KiBuildProcessRootView(const KE_PROCESS_ADDRESS_SPACE *procSpace, KE_KERNEL_ADDRESS_SPACE *outView);
 static HO_STATUS KiValidateCreateParams(const KE_USER_BOOTSTRAP_CREATE_PARAMS *params);
 static HO_STATUS KiValidateBootstrapHole(const KE_KERNEL_ADDRESS_SPACE *space, HO_VIRTUAL_ADDRESS virtAddr);
 static HO_STATUS KiPopulatePhysicalPage(HO_PHYSICAL_ADDRESS physAddr, const void *bytes, uint64_t byteCount);
@@ -71,6 +73,14 @@ static HO_STATUS KiAllocateAndMapUserPage(const KE_KERNEL_ADDRESS_SPACE *space,
 static const KE_USER_BOOTSTRAP_MAPPING_RECORD *KiFindMappedPage(const KE_USER_BOOTSTRAP_STAGING *staging,
                                                                 KE_USER_BOOTSTRAP_MAPPING_KIND kind);
 static KE_USER_BOOTSTRAP_STAGING *KiGetCurrentThreadStaging(void);
+
+static void
+KiBuildProcessRootView(const KE_PROCESS_ADDRESS_SPACE *procSpace, KE_KERNEL_ADDRESS_SPACE *outView)
+{
+    memset(outView, 0, sizeof(*outView));
+    outView->RootPageTablePhys = procSpace->RootPageTablePhys;
+    outView->Initialized = procSpace->Initialized;
+}
 
 static HO_STATUS
 KiValidateCreateParams(const KE_USER_BOOTSTRAP_CREATE_PARAMS *params)
@@ -227,22 +237,30 @@ KiGetCurrentThreadStaging(void)
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS
 KeUserBootstrapCreateStaging(const KE_USER_BOOTSTRAP_CREATE_PARAMS *params,
+                             KE_PROCESS_ADDRESS_SPACE *targetSpace,
                              KE_USER_BOOTSTRAP_STAGING **outStaging)
 {
     HO_STATUS destroyStatus = EC_SUCCESS;
+    KE_KERNEL_ADDRESS_SPACE processView = {0};
 
     if (!outStaging)
         return EC_ILLEGAL_ARGUMENT;
 
     *outStaging = NULL;
 
+    if (targetSpace == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (!targetSpace->Initialized)
+        return EC_INVALID_STATE;
+
     HO_STATUS status = KiValidateCreateParams(params);
     if (status != EC_SUCCESS)
         return status;
 
-    const KE_KERNEL_ADDRESS_SPACE *space = KeGetKernelAddressSpace();
-    if (!space || !space->Initialized)
-        return EC_INVALID_STATE;
+    KiBuildProcessRootView(targetSpace, &processView);
+
+    const KE_KERNEL_ADDRESS_SPACE *space = &processView;
 
     status = KiValidateBootstrapHole(space, 0);
     if (status != EC_SUCCESS)
@@ -273,6 +291,7 @@ KeUserBootstrapCreateStaging(const KE_USER_BOOTSTRAP_CREATE_PARAMS *params,
     staging->StackTop = KE_USER_BOOTSTRAP_STACK_TOP;
     staging->GuardBase = KE_USER_BOOTSTRAP_STACK_GUARD_BASE;
     staging->PhaseOneMailboxAddress = KE_USER_BOOTSTRAP_STACK_MAILBOX_ADDRESS;
+    staging->OwnerRootPageTablePhys = targetSpace->RootPageTablePhys;
 
     status = KiAllocateAndMapUserPage(space,
                                       staging,
@@ -311,7 +330,28 @@ KeUserBootstrapCreateStaging(const KE_USER_BOOTSTRAP_CREATE_PARAMS *params,
     if (status != EC_SUCCESS)
         goto cleanup;
 
-    *(volatile uint32_t *)(uint64_t)staging->PhaseOneMailboxAddress = KE_USER_BOOTSTRAP_P1_MAILBOX_CLOSED;
+    const KE_USER_BOOTSTRAP_MAPPING_RECORD *stackRecord =
+        KiFindMappedPage(staging, KE_USER_BOOTSTRAP_MAPPING_KIND_STACK);
+    HO_KASSERT(stackRecord != NULL, EC_INVALID_STATE);
+
+    KE_TEMP_PHYS_MAP_HANDLE mailboxHandle = {0};
+    HO_VIRTUAL_ADDRESS mailboxTempVirt = 0;
+    status = KeTempPhysMapAcquire(stackRecord->PhysicalBase,
+                                  PTE_WRITABLE | PTE_NO_EXECUTE,
+                                  &mailboxHandle,
+                                  &mailboxTempVirt);
+    if (status != EC_SUCCESS)
+        goto cleanup;
+
+    *(volatile uint32_t *)(uint64_t)(mailboxTempVirt + KE_USER_BOOTSTRAP_STACK_MAILBOX_OFFSET) =
+        KE_USER_BOOTSTRAP_P1_MAILBOX_CLOSED;
+
+    HO_STATUS mailboxRelease = KeTempPhysMapRelease(&mailboxHandle);
+    if (mailboxRelease != EC_SUCCESS)
+    {
+        status = mailboxRelease;
+        goto cleanup;
+    }
 
     *outStaging = staging;
     return EC_SUCCESS;
@@ -330,7 +370,10 @@ KeUserBootstrapDestroyStaging(KE_USER_BOOTSTRAP_STAGING *staging)
         return EC_ILLEGAL_ARGUMENT;
 
     HO_STATUS firstError = EC_SUCCESS;
-    const KE_KERNEL_ADDRESS_SPACE *space = KeGetKernelAddressSpace();
+    KE_KERNEL_ADDRESS_SPACE ownerView = {0};
+    ownerView.RootPageTablePhys = staging->OwnerRootPageTablePhys;
+    ownerView.Initialized = (staging->OwnerRootPageTablePhys != 0);
+    const KE_KERNEL_ADDRESS_SPACE *space = &ownerView;
 
     if (staging->AttachedThread != NULL)
     {

--- a/src/kernel/ke/user_bootstrap_syscall.c
+++ b/src/kernel/ke/user_bootstrap_syscall.c
@@ -154,8 +154,16 @@ KiCopyInBootstrapUserBytes(void *kernelDestination, HO_VIRTUAL_ADDRESS userSourc
         return status;
     }
 
-    const KE_KERNEL_ADDRESS_SPACE *space = KeGetKernelAddressSpace();
-    status = KiValidateBootstrapUserReadablePages(space, userSource, endExclusive);
+    HO_PHYSICAL_ADDRESS activeRoot = 0;
+    status = KeQueryActiveRootPageTable(&activeRoot);
+    if (status != EC_SUCCESS)
+        return status;
+
+    KE_KERNEL_ADDRESS_SPACE activeView = {0};
+    activeView.RootPageTablePhys = activeRoot;
+    activeView.Initialized = TRUE;
+
+    status = KiValidateBootstrapUserReadablePages(&activeView, userSource, endExclusive);
     if (status != EC_SUCCESS)
         return status;
 


### PR DESCRIPTION
## What Changed

Promote `EX_PROCESS` from a staging-only wrapper into the owner of the process-private address space used during bootstrap.

- create the process-private root earlier in `ExBootstrapCreateProcess()` and stage bootstrap payload pages into that root instead of the shared imported kernel root
- extend `EX_PROCESS` and bootstrap staging state to track the target address space and root page table ownership for cleanup
- switch bootstrap enter/exit paths to install the process root before Ring 3 entry and restore the kernel root before teardown
- update bootstrap syscall-side page validation to query the active process root while the syscall is executing

## Why

Bootstrap payload pages should belong to the process-private address space that the new process owns. Before this change, those pages were staged into the shared imported kernel root, which meant ownership and teardown responsibilities were split across layers.

## Impact

- keeps bootstrap code, const data, stack, and guard pages under the `EX_PROCESS` address-space contract
- makes teardown paths clean up staging state and the private root in the same lifecycle
- preserves the existing `user_hello` bootstrap behavior while moving ownership to the process-private root

## Validation

- `scripts/qemu_capture.sh` with `BUILD_FLAVOR=test-user_hello`
- verified the `user_hello` P1/P2/P3 evidence chain remained unchanged