### PR TITLE
bootstrap dispatch and syscall layout validation

### DIFF
--- a/src/include/kernel/ex/ex_bootstrap_abi.h
+++ b/src/include/kernel/ex/ex_bootstrap_abi.h
@@ -11,12 +11,12 @@
 #include <_hobase.h>
 
 /*
- * Fixed low-half bootstrap-only layout.  These constants define the user
- * window that the bootstrap staging path maps for each process.  When the
- * owning EX_PROCESS holds a process-private root, the pages live in that
- * root's low-half rather than the shared imported kernel root.  The layout
- * constants remain fixed for the bootstrap-only slice; a dynamic per-process
- * layout allocator is a future phase.
+ * Bootstrap layout defaults for the current bring-up path. The live contract
+ * comes from the current thread's attached staging/process state, while these
+ * constants remain the default placements used when that layout is created.
+ * When the owning EX_PROCESS holds a process-private root, the pages live in
+ * that root's low-half rather than the shared imported kernel root. A dynamic
+ * per-process layout allocator is a future phase.
  */
 #define KE_USER_BOOTSTRAP_PAGE_SIZE              0x1000ULL
 #define KE_USER_BOOTSTRAP_WINDOW_BASE            0x0000000080000000ULL
@@ -24,6 +24,7 @@
 #define KE_USER_BOOTSTRAP_WINDOW_END_EXCLUSIVE   (KE_USER_BOOTSTRAP_WINDOW_BASE +                     \
                                                   (KE_USER_BOOTSTRAP_WINDOW_PAGE_COUNT *              \
                                                    KE_USER_BOOTSTRAP_PAGE_SIZE))
+/* Default single-page placements inside the current bootstrap layout. */
 #define KE_USER_BOOTSTRAP_CODE_BASE              KE_USER_BOOTSTRAP_WINDOW_BASE
 #define KE_USER_BOOTSTRAP_CONST_BASE             (KE_USER_BOOTSTRAP_CODE_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
 #define KE_USER_BOOTSTRAP_STACK_GUARD_BASE       (KE_USER_BOOTSTRAP_CONST_BASE + KE_USER_BOOTSTRAP_PAGE_SIZE)
@@ -55,12 +56,14 @@
 /*
  * Bootstrap raw write keeps both rejection and success paths on the same
  * helper family in ke/user_bootstrap_syscall.c:
- * - validate the fixed bootstrap user window range
- * - validate that covered pages remain user accessible
+ * - query the current thread's live bootstrap layout from Ke staging state
+ * - validate the supplied range against that live layout
+ * - validate that covered pages remain user accessible in the layout owner's root
  * - bounded copy-in into a kernel scratch buffer
  *
  * Stable user_hello evidence-chain anchors then record P1 milestones first,
- * followed by raw-write rejection/success and raw-exit handoff.
+ * followed by raw-write rejection/success and raw-exit handoff. The fixed
+ * addresses above remain bootstrap layout defaults, not a shared-root ABI.
  */
 #define KE_USER_BOOTSTRAP_LOG_ENTER_USER_MODE          "[USERBOOT] enter user mode"
 #define KE_USER_BOOTSTRAP_LOG_P1_FIRST_ENTRY           KE_USER_BOOTSTRAP_LOG_ENTER_USER_MODE

--- a/src/include/kernel/ke/bootstrap_callbacks.h
+++ b/src/include/kernel/ke/bootstrap_callbacks.h
@@ -25,6 +25,15 @@ typedef void (*KE_BOOTSTRAP_ENTER_FN)(struct KTHREAD *thread) HO_NORETURN;
 typedef BOOL (*KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN)(const struct KTHREAD *thread);
 
 /**
+ * Bootstrap thread root query callback - called by Ke-side dispatch paths to
+ * resolve a thread's target address-space root as an opaque physical identity.
+ * May run before the thread's first enter callback, so it must not depend on
+ * bootstrap-enter side effects.
+ */
+typedef HO_STATUS (*KE_BOOTSTRAP_THREAD_ROOT_QUERY_FN)(const struct KTHREAD *thread,
+                                                       HO_PHYSICAL_ADDRESS *outRootPageTablePhys);
+
+/**
  * Bootstrap finalize callback - called from thread finalizer when a
  * terminated thread may hold bootstrap resources.
  * Return EC_SUCCESS if nothing needs to be cleaned; error propagates.
@@ -38,16 +47,18 @@ typedef HO_STATUS (*KE_BOOTSTRAP_FINALIZE_FN)(struct KTHREAD *thread);
 typedef void (*KE_BOOTSTRAP_TIMER_OBSERVE_FN)(struct KTHREAD *thread);
 
 /**
- * Register bootstrap callbacks. All four must be non-NULL.
- * Must be called before any bootstrap user thread is scheduled.
+ * Register bootstrap callbacks. All five must be non-NULL.
+ * Must be called before any bootstrap user thread can be dispatched.
  * May only be called once.
  */
 HO_KERNEL_API HO_STATUS KeRegisterBootstrapCallbacks(KE_BOOTSTRAP_ENTER_FN enterFn,
                                                      KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN threadOwnershipQueryFn,
+                                                     KE_BOOTSTRAP_THREAD_ROOT_QUERY_FN threadRootQueryFn,
                                                      KE_BOOTSTRAP_FINALIZE_FN finalizeFn,
                                                      KE_BOOTSTRAP_TIMER_OBSERVE_FN timerObserveFn);
 
 KE_BOOTSTRAP_ENTER_FN KiGetBootstrapEnterCallback(void);
 KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN KiGetBootstrapThreadOwnershipQueryCallback(void);
+KE_BOOTSTRAP_THREAD_ROOT_QUERY_FN KiGetBootstrapThreadRootQueryCallback(void);
 KE_BOOTSTRAP_FINALIZE_FN KiGetBootstrapFinalizeCallback(void);
 KE_BOOTSTRAP_TIMER_OBSERVE_FN KiGetBootstrapTimerObserveCallback(void);

--- a/src/include/kernel/ke/user_bootstrap.h
+++ b/src/include/kernel/ke/user_bootstrap.h
@@ -25,6 +25,18 @@ typedef struct KE_USER_BOOTSTRAP_CREATE_PARAMS
     uint64_t ConstLength;
 } KE_USER_BOOTSTRAP_CREATE_PARAMS;
 
+typedef struct KE_USER_BOOTSTRAP_LAYOUT
+{
+    HO_VIRTUAL_ADDRESS UserRangeBase;
+    HO_VIRTUAL_ADDRESS UserRangeEndExclusive;
+    HO_VIRTUAL_ADDRESS EntryPoint;
+    HO_VIRTUAL_ADDRESS GuardBase;
+    HO_VIRTUAL_ADDRESS StackBase;
+    HO_VIRTUAL_ADDRESS StackTop;
+    HO_VIRTUAL_ADDRESS PhaseOneMailboxAddress;
+    HO_PHYSICAL_ADDRESS OwnerRootPageTablePhys;
+} KE_USER_BOOTSTRAP_LAYOUT;
+
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapCreateStaging(
     const KE_USER_BOOTSTRAP_CREATE_PARAMS *params,
     KE_PROCESS_ADDRESS_SPACE *targetSpace,
@@ -34,6 +46,13 @@ HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapDestroyStaging(KE_USER_BOOTS
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapAttachThread(KTHREAD *thread,
                                                                  KE_USER_BOOTSTRAP_STAGING *staging);
+
+/*
+ * Query the live bootstrap layout attached to the current thread. The range
+ * spans the full bootstrap slice so guard holes remain range-valid and are
+ * rejected later by page validation rather than by the range gate.
+ */
+HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapQueryCurrentThreadLayout(KE_USER_BOOTSTRAP_LAYOUT *outLayout);
 
 HO_KERNEL_API HO_NODISCARD HO_STATUS KeUserBootstrapRawSyscallInit(void);
 

--- a/src/kernel/ex/ex_bootstrap_adapter.c
+++ b/src/kernel/ex/ex_bootstrap_adapter.c
@@ -8,9 +8,7 @@
 
 #include "ex_bootstrap_internal.h"
 
-#include <arch/amd64/pm.h>
 #include <kernel/ex/ex_bootstrap_adapter.h>
-#include <kernel/init.h>
 #include <kernel/ke/bootstrap_callbacks.h>
 #include <kernel/ke/kthread.h>
 #include <kernel/ke/mm.h>
@@ -18,6 +16,7 @@
 #include <kernel/hodbg.h>
 
 static void KiDestroyBootstrapWrapperObjects(void);
+static HO_STATUS KiRestoreImportedRootForProcessTeardown(const EX_PROCESS *process);
 
 static HO_NORETURN void
 ExBootstrapEnterCallback(KTHREAD *thread)
@@ -33,28 +32,49 @@ ExBootstrapEnterCallback(KTHREAD *thread)
         HO_KPANIC(EC_INVALID_STATE, "Bootstrap enter: process root not initialized");
     }
 
-    status = KeSwitchAddressSpace(gExBootstrapProcess->AddressSpace.RootPageTablePhys);
+    if (gExBootstrapProcess->AddressSpace.RootPageTablePhys == 0)
+    {
+        HO_KPANIC(EC_INVALID_STATE, "Bootstrap enter: process root missing");
+    }
+
+    HO_PHYSICAL_ADDRESS activeRoot = 0;
+    status = KeQueryActiveRootPageTable(&activeRoot);
     if (status != EC_SUCCESS)
     {
-        HO_KPANIC(status, "Bootstrap enter: failed to install process root");
+        HO_KPANIC(status, "Bootstrap enter: failed to query active root");
     }
 
-    BOOT_CAPSULE *bootCapsule = KeGetBootCapsule();
-    if (bootCapsule == NULL)
+    if (activeRoot != gExBootstrapProcess->AddressSpace.RootPageTablePhys)
     {
-        HO_KPANIC(EC_INVALID_STATE, "Bootstrap enter: boot capsule unavailable");
+        HO_KPANIC(EC_INVALID_STATE, "Bootstrap enter: dispatch root not installed");
     }
-
-    TSS64 tss = bootCapsule->CpuInfo.Tss;
-    if (InitCpuCoreLocalData(&bootCapsule->CpuInfo, sizeof(bootCapsule->CpuInfo)) == NULL)
-    {
-        HO_KPANIC(EC_INVALID_STATE, "Bootstrap enter: failed to rebuild high-half GDT/TSS");
-    }
-
-    bootCapsule->CpuInfo.Tss = tss;
-    LoadGdtAndTss(&bootCapsule->CpuInfo);
 
     KeUserBootstrapEnterCurrentThread();
+}
+
+static HO_STATUS
+KiRestoreImportedRootForProcessTeardown(const EX_PROCESS *process)
+{
+    HO_PHYSICAL_ADDRESS activeRoot = 0;
+
+    if (process == NULL || !process->AddressSpace.Initialized)
+    {
+        return EC_SUCCESS;
+    }
+
+    if (KeQueryActiveRootPageTable(&activeRoot) != EC_SUCCESS ||
+        activeRoot != process->AddressSpace.RootPageTablePhys)
+    {
+        return EC_SUCCESS;
+    }
+
+    const KE_KERNEL_ADDRESS_SPACE *kernelSpace = KeGetKernelAddressSpace();
+    if (kernelSpace == NULL || !kernelSpace->Initialized || kernelSpace->RootPageTablePhys == 0)
+    {
+        return EC_INVALID_STATE;
+    }
+
+    return KeSwitchAddressSpace(kernelSpace->RootPageTablePhys);
 }
 
 static BOOL
@@ -143,19 +163,7 @@ ExBootstrapAdapterFinalizeThread(KTHREAD *thread)
 
     process = gExBootstrapThread->Process;
 
-    /* Ensure the kernel root is active before tearing down the process root. */
-    if (process != NULL && process->AddressSpace.Initialized)
-    {
-        HO_PHYSICAL_ADDRESS activeRoot = 0;
-        if (KeQueryActiveRootPageTable(&activeRoot) == EC_SUCCESS &&
-            activeRoot == process->AddressSpace.RootPageTablePhys)
-        {
-            const KE_KERNEL_ADDRESS_SPACE *kernelSpace = KeGetKernelAddressSpace();
-            HO_STATUS switchStatus = KeSwitchAddressSpace(kernelSpace->RootPageTablePhys);
-            if (switchStatus != EC_SUCCESS)
-                status = switchStatus;
-        }
-    }
+    status = KiRestoreImportedRootForProcessTeardown(process);
 
     if (process != NULL && process->Staging != NULL)
     {
@@ -214,10 +222,7 @@ ExBootstrapAdapterHandleRawExit(KTHREAD *thread)
     if (process == NULL || process->Staging == NULL)
         return EC_INVALID_STATE;
 
-    /* Restore the kernel root before teardown so DestroyProcessAddressSpace
-       sees a non-active root and staging unmap operates on a non-active PT. */
-    const KE_KERNEL_ADDRESS_SPACE *kernelSpace = KeGetKernelAddressSpace();
-    HO_STATUS status = KeSwitchAddressSpace(kernelSpace->RootPageTablePhys);
+    HO_STATUS status = KiRestoreImportedRootForProcessTeardown(process);
     if (status != EC_SUCCESS)
         return status;
 

--- a/src/kernel/ex/ex_bootstrap_adapter.c
+++ b/src/kernel/ex/ex_bootstrap_adapter.c
@@ -64,6 +64,32 @@ ExBootstrapThreadOwnershipQueryCallback(const KTHREAD *thread)
 }
 
 static HO_STATUS
+ExBootstrapThreadRootQueryCallback(const KTHREAD *thread, HO_PHYSICAL_ADDRESS *outRootPageTablePhys)
+{
+    const KE_KERNEL_ADDRESS_SPACE *kernelSpace = KeGetKernelAddressSpace();
+
+    if (thread == NULL || outRootPageTablePhys == NULL)
+        return EC_ILLEGAL_ARGUMENT;
+
+    if (kernelSpace == NULL || !kernelSpace->Initialized || kernelSpace->RootPageTablePhys == 0)
+        return EC_INVALID_STATE;
+
+    *outRootPageTablePhys = kernelSpace->RootPageTablePhys;
+
+    if (gExBootstrapThread != NULL && gExBootstrapThread->Thread == thread)
+    {
+        EX_PROCESS *process = gExBootstrapThread->Process;
+
+        if (process == NULL || !process->AddressSpace.Initialized || process->AddressSpace.RootPageTablePhys == 0)
+            return EC_INVALID_STATE;
+
+        *outRootPageTablePhys = process->AddressSpace.RootPageTablePhys;
+    }
+
+    return EC_SUCCESS;
+}
+
+static HO_STATUS
 ExBootstrapFinalizeCallback(KTHREAD *thread)
 {
     if (thread != NULL && ExBootstrapAdapterQueryThreadStaging(thread) != NULL)
@@ -86,6 +112,7 @@ ExBootstrapAdapterInit(void)
 {
     return KeRegisterBootstrapCallbacks(ExBootstrapEnterCallback,
                                         ExBootstrapThreadOwnershipQueryCallback,
+                                        ExBootstrapThreadRootQueryCallback,
                                         ExBootstrapFinalizeCallback,
                                         ExBootstrapTimerObserveCallback);
 }

--- a/src/kernel/init/cpu.c
+++ b/src/kernel/init/cpu.c
@@ -17,4 +17,13 @@ InitCpuState(STAGING_BLOCK *block)
     data->Tss.IST1 = HHDM_PHYS2VIRT(block->KrnlIST1StackPhys) + block->Layout.IST1StackSize;
     data->Tss.IST2 = HHDM_PHYS2VIRT(block->KrnlIST2StackPhys) + block->Layout.IST2StackSize;
     data->Tss.IOMapBase = sizeof(TSS64); // No IO permission bitmap
+
+    TSS64 tss = data->Tss;
+    if (InitCpuCoreLocalData(data, sizeof(*data)) == NULL)
+    {
+        HO_KPANIC(EC_INVALID_STATE, "Failed to initialize high-half GDT/TSS");
+    }
+
+    data->Tss = tss;
+    LoadGdtAndTss(data);
 }

--- a/src/kernel/ke/bootstrap_callbacks.c
+++ b/src/kernel/ke/bootstrap_callbacks.c
@@ -10,21 +10,25 @@
 
 static KE_BOOTSTRAP_ENTER_FN gBootstrapEnterCallback = NULL;
 static KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN gBootstrapThreadOwnershipQueryCallback = NULL;
+static KE_BOOTSTRAP_THREAD_ROOT_QUERY_FN gBootstrapThreadRootQueryCallback = NULL;
 static KE_BOOTSTRAP_FINALIZE_FN gBootstrapFinalizeCallback = NULL;
 static KE_BOOTSTRAP_TIMER_OBSERVE_FN gBootstrapTimerObserveCallback = NULL;
 
 HO_KERNEL_API HO_STATUS
 KeRegisterBootstrapCallbacks(KE_BOOTSTRAP_ENTER_FN enterFn,
                              KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN threadOwnershipQueryFn,
+                             KE_BOOTSTRAP_THREAD_ROOT_QUERY_FN threadRootQueryFn,
                              KE_BOOTSTRAP_FINALIZE_FN finalizeFn,
                              KE_BOOTSTRAP_TIMER_OBSERVE_FN timerObserveFn)
 {
-    if (enterFn == NULL || threadOwnershipQueryFn == NULL || finalizeFn == NULL || timerObserveFn == NULL)
+    if (enterFn == NULL || threadOwnershipQueryFn == NULL || threadRootQueryFn == NULL || finalizeFn == NULL ||
+        timerObserveFn == NULL)
     {
         return EC_ILLEGAL_ARGUMENT;
     }
 
     if (gBootstrapEnterCallback != NULL || gBootstrapThreadOwnershipQueryCallback != NULL ||
+        gBootstrapThreadRootQueryCallback != NULL ||
         gBootstrapFinalizeCallback != NULL ||
         gBootstrapTimerObserveCallback != NULL)
     {
@@ -33,6 +37,7 @@ KeRegisterBootstrapCallbacks(KE_BOOTSTRAP_ENTER_FN enterFn,
 
     gBootstrapEnterCallback = enterFn;
     gBootstrapThreadOwnershipQueryCallback = threadOwnershipQueryFn;
+    gBootstrapThreadRootQueryCallback = threadRootQueryFn;
     gBootstrapFinalizeCallback = finalizeFn;
     gBootstrapTimerObserveCallback = timerObserveFn;
     return EC_SUCCESS;
@@ -48,6 +53,12 @@ KE_BOOTSTRAP_THREAD_OWNERSHIP_QUERY_FN
 KiGetBootstrapThreadOwnershipQueryCallback(void)
 {
     return gBootstrapThreadOwnershipQueryCallback;
+}
+
+KE_BOOTSTRAP_THREAD_ROOT_QUERY_FN
+KiGetBootstrapThreadRootQueryCallback(void)
+{
+    return gBootstrapThreadRootQueryCallback;
 }
 
 KE_BOOTSTRAP_FINALIZE_FN

--- a/src/kernel/ke/thread/scheduler/scheduler.c
+++ b/src/kernel/ke/thread/scheduler/scheduler.c
@@ -303,6 +303,32 @@ KiIsBootstrapOwnedThread(const KTHREAD *thread)
     return threadOwnershipQueryFn(thread);
 }
 
+static HO_PHYSICAL_ADDRESS
+KiResolveDispatchRoot(const KTHREAD *thread)
+{
+    HO_KASSERT(thread != NULL, EC_ILLEGAL_ARGUMENT);
+
+    KE_BOOTSTRAP_THREAD_ROOT_QUERY_FN threadRootQueryFn = KiGetBootstrapThreadRootQueryCallback();
+    if (threadRootQueryFn == NULL)
+    {
+        HO_KPANIC(EC_INVALID_STATE, "Bootstrap root query callback not registered");
+    }
+
+    HO_PHYSICAL_ADDRESS rootPageTablePhys = 0;
+    HO_STATUS status = threadRootQueryFn(thread, &rootPageTablePhys);
+    if (status != EC_SUCCESS)
+    {
+        HO_KPANIC(status, "Failed to resolve dispatch root for KTHREAD");
+    }
+
+    if (rootPageTablePhys == 0)
+    {
+        HO_KPANIC(EC_INVALID_STATE, "Bootstrap root query returned invalid root");
+    }
+
+    return rootPageTablePhys;
+}
+
 void
 KiFinalizeThread(KTHREAD *thread)
 {
@@ -581,6 +607,8 @@ KiSchedule(void)
         return;
     }
 
+    HO_PHYSICAL_ADDRESS nextRootPageTablePhys = KiResolveDispatchRoot(next);
+
     next->State = KTHREAD_STATE_RUNNING;
     gStats.ContextSwitchCount++;
 
@@ -593,6 +621,12 @@ KiSchedule(void)
     // Arm clock event for next deadline
     uint64_t nowNs = KiNowNs();
     KiArmForNextEvent(nowNs, next);
+
+    HO_STATUS switchStatus = KeSwitchAddressSpace(nextRootPageTablePhys);
+    if (switchStatus != EC_SUCCESS)
+    {
+        HO_KPANIC(switchStatus, "Failed to install dispatch root");
+    }
 
     gCurrentThread = next;
     KeSetCurrentIrqlState(&next->IrqlState);

--- a/src/kernel/ke/user_bootstrap.c
+++ b/src/kernel/ke/user_bootstrap.c
@@ -439,6 +439,45 @@ KeUserBootstrapAttachThread(KTHREAD *thread, KE_USER_BOOTSTRAP_STAGING *staging)
     return EC_SUCCESS;
 }
 
+HO_KERNEL_API HO_NODISCARD HO_STATUS
+KeUserBootstrapQueryCurrentThreadLayout(KE_USER_BOOTSTRAP_LAYOUT *outLayout)
+{
+    if (!outLayout)
+        return EC_ILLEGAL_ARGUMENT;
+
+    memset(outLayout, 0, sizeof(*outLayout));
+
+    KE_USER_BOOTSTRAP_STAGING *staging = KiGetCurrentThreadStaging();
+    if (staging == NULL)
+        return EC_INVALID_STATE;
+
+    const KE_USER_BOOTSTRAP_MAPPING_RECORD *codeRecord =
+        KiFindMappedPage(staging, KE_USER_BOOTSTRAP_MAPPING_KIND_CODE);
+    const KE_USER_BOOTSTRAP_MAPPING_RECORD *stackRecord =
+        KiFindMappedPage(staging, KE_USER_BOOTSTRAP_MAPPING_KIND_STACK);
+    if (codeRecord == NULL || stackRecord == NULL)
+        return EC_INVALID_STATE;
+
+    if (staging->OwnerRootPageTablePhys == 0)
+        return EC_INVALID_STATE;
+
+    if (staging->StackTop <= codeRecord->VirtualBase)
+        return EC_INVALID_STATE;
+
+    if (stackRecord->VirtualBase != staging->StackBase)
+        return EC_INVALID_STATE;
+
+    outLayout->UserRangeBase = codeRecord->VirtualBase;
+    outLayout->UserRangeEndExclusive = staging->StackTop;
+    outLayout->EntryPoint = staging->EntryPoint;
+    outLayout->GuardBase = staging->GuardBase;
+    outLayout->StackBase = staging->StackBase;
+    outLayout->StackTop = staging->StackTop;
+    outLayout->PhaseOneMailboxAddress = staging->PhaseOneMailboxAddress;
+    outLayout->OwnerRootPageTablePhys = staging->OwnerRootPageTablePhys;
+    return EC_SUCCESS;
+}
+
 HO_KERNEL_API void
 KeUserBootstrapObserveCurrentThreadUserTimerPreemption(void)
 {

--- a/src/kernel/ke/user_bootstrap_syscall.c
+++ b/src/kernel/ke/user_bootstrap_syscall.c
@@ -23,7 +23,8 @@ static HO_NORETURN void KiAbortRawExit(KTHREAD *thread,
                                        uint64_t exitCode,
                                        HO_STATUS status,
                                        const char *reason);
-static HO_STATUS KiValidateBootstrapUserRange(HO_VIRTUAL_ADDRESS userBase,
+static HO_STATUS KiValidateBootstrapUserRange(const KE_USER_BOOTSTRAP_LAYOUT *layout,
+                                              HO_VIRTUAL_ADDRESS userBase,
                                               uint64_t length,
                                               HO_VIRTUAL_ADDRESS *outEndExclusive);
 static HO_STATUS KiValidateBootstrapUserReadablePages(const KE_KERNEL_ADDRESS_SPACE *space,
@@ -56,10 +57,16 @@ KiAbortRawExit(KTHREAD *thread, uint64_t exitCode, HO_STATUS status, const char 
 }
 
 static HO_STATUS
-KiValidateBootstrapUserRange(HO_VIRTUAL_ADDRESS userBase, uint64_t length, HO_VIRTUAL_ADDRESS *outEndExclusive)
+KiValidateBootstrapUserRange(const KE_USER_BOOTSTRAP_LAYOUT *layout,
+                             HO_VIRTUAL_ADDRESS userBase,
+                             uint64_t length,
+                             HO_VIRTUAL_ADDRESS *outEndExclusive)
 {
-    if (!outEndExclusive)
+    if (!layout || !outEndExclusive)
         return EC_ILLEGAL_ARGUMENT;
+
+    if (layout->UserRangeEndExclusive <= layout->UserRangeBase)
+        return EC_INVALID_STATE;
 
     if (length == 0)
     {
@@ -67,17 +74,17 @@ KiValidateBootstrapUserRange(HO_VIRTUAL_ADDRESS userBase, uint64_t length, HO_VI
         return EC_SUCCESS;
     }
 
-    if (userBase < KE_USER_BOOTSTRAP_WINDOW_BASE)
+    if (userBase < layout->UserRangeBase)
         return EC_ILLEGAL_ARGUMENT;
 
-    if (userBase >= KE_USER_BOOTSTRAP_WINDOW_END_EXCLUSIVE)
+    if (userBase >= layout->UserRangeEndExclusive)
         return EC_ILLEGAL_ARGUMENT;
 
     HO_VIRTUAL_ADDRESS endExclusive = userBase + length;
     if (endExclusive < userBase)
         return EC_ILLEGAL_ARGUMENT;
 
-    if (endExclusive > KE_USER_BOOTSTRAP_WINDOW_END_EXCLUSIVE)
+    if (endExclusive > layout->UserRangeEndExclusive)
         return EC_ILLEGAL_ARGUMENT;
 
     *outEndExclusive = endExclusive;
@@ -141,8 +148,13 @@ KiCopyInBootstrapUserBytes(void *kernelDestination, HO_VIRTUAL_ADDRESS userSourc
     if (length == 0)
         return EC_SUCCESS;
 
+    KE_USER_BOOTSTRAP_LAYOUT layout = {0};
+    HO_STATUS status = KeUserBootstrapQueryCurrentThreadLayout(&layout);
+    if (status != EC_SUCCESS)
+        return status;
+
     HO_VIRTUAL_ADDRESS endExclusive = 0;
-    HO_STATUS status = KiValidateBootstrapUserRange(userSource, length, &endExclusive);
+    status = KiValidateBootstrapUserRange(&layout, userSource, length, &endExclusive);
     if (status != EC_SUCCESS)
     {
         klog(KLOG_LEVEL_WARNING,
@@ -159,11 +171,22 @@ KiCopyInBootstrapUserBytes(void *kernelDestination, HO_VIRTUAL_ADDRESS userSourc
     if (status != EC_SUCCESS)
         return status;
 
-    KE_KERNEL_ADDRESS_SPACE activeView = {0};
-    activeView.RootPageTablePhys = activeRoot;
-    activeView.Initialized = TRUE;
+    if (activeRoot != layout.OwnerRootPageTablePhys)
+    {
+        klog(KLOG_LEVEL_WARNING,
+             KE_USER_BOOTSTRAP_LOG_INVALID_USER_BUFFER " active-root=%p owner-root=%p addr=%p len=%lu\n",
+             (void *)(uint64_t)activeRoot,
+             (void *)(uint64_t)layout.OwnerRootPageTablePhys,
+             (void *)(uint64_t)userSource,
+             (unsigned long)length);
+        return EC_INVALID_STATE;
+    }
 
-    status = KiValidateBootstrapUserReadablePages(&activeView, userSource, endExclusive);
+    KE_KERNEL_ADDRESS_SPACE ownerView = {0};
+    ownerView.RootPageTablePhys = layout.OwnerRootPageTablePhys;
+    ownerView.Initialized = TRUE;
+
+    status = KiValidateBootstrapUserReadablePages(&ownerView, userSource, endExclusive);
     if (status != EC_SUCCESS)
         return status;
 


### PR DESCRIPTION
## Summary
- switch bootstrap dispatch into the target address space instead of running entirely through the root bridge
- narrow the enter/teardown bridge so the root mappings are only used around the transition boundary
- validate bootstrap syscalls against the live user bootstrap layout and expose the layout helpers needed by the syscall path

## Why
Bootstrap execution now depends on the live address-space layout being active during dispatch. This PR makes that transition explicit and keeps syscall validation aligned with the real bootstrap image layout to avoid stale assumptions during early user execution.

## Impact
- bootstrap callbacks can enter dispatch with the correct address space installed
- adapter teardown is reduced to the minimum bridge window
- user bootstrap syscall handling validates against the live layout before operating on bootstrap state

## Validation
- `make -j4`